### PR TITLE
chore: remove puppeteer from tx-automation

### DIFF
--- a/platforms/guardoni/tsconfig.json
+++ b/platforms/guardoni/tsconfig.json
@@ -23,11 +23,6 @@
     ],
     "paths": {
       "@shared/*": ["../../../packages/shared/src/*"],
-      "@experiment/*": ["./guardoni/tx-automate/experiment/*"],
-      "@project/*": ["./guardoni/tx-automate/project/*"],
-      "@platform/*": ["./guardoni/tx-automate/platform/*"],
-      "@storage/*": ["./guardoni/tx-automate/storage/*"],
-      "@util/*": ["./guardoni/tx-automate/util/*"],
       "@yttrex/shared/*": ["../../yttrex/shared/src/*"],
       "@tktrex/shared/*": ["../../tktrex/shared/src/*"]
     }

--- a/platforms/tktrex/tt-automate/package.json
+++ b/platforms/tktrex/tt-automate/package.json
@@ -58,7 +58,7 @@
     "node-fetch": "^2.6.7",
     "pouchdb-find": "^7.2.2",
     "pouchdb-node": "^7.2.2",
-    "puppeteer": "^13.7.0",
+    "puppeteer-core": "^13.7.0",
     "puppeteer-extra": "^3.2.3",
     "puppeteer-extra-plugin-stealth": "^2.9.0",
     "ts-jest": "^27.1.5",

--- a/platforms/tktrex/tt-automate/src/experiment/index.ts
+++ b/platforms/tktrex/tt-automate/src/experiment/index.ts
@@ -1,4 +1,4 @@
-import { Page } from 'puppeteer';
+import { Page } from 'puppeteer-core';
 import { Logger } from '@util/logger';
 import { BaseModel, StorableObject } from '@storage/db';
 import { MinimalProjectConfig } from '../config';

--- a/platforms/tktrex/tt-automate/src/platform/TikTok/util/page.ts
+++ b/platforms/tktrex/tt-automate/src/platform/TikTok/util/page.ts
@@ -1,4 +1,4 @@
-import { Page } from 'puppeteer';
+import { Page } from 'puppeteer-core';
 
 import { askConfirmation } from '@util/page';
 

--- a/platforms/tktrex/tt-automate/src/platform/TikTok/util/project.ts
+++ b/platforms/tktrex/tt-automate/src/platform/TikTok/util/project.ts
@@ -2,7 +2,7 @@ import { resolve } from 'path';
 import { createReadStream } from 'fs';
 import { mkdir } from 'fs/promises';
 
-import { Page } from 'puppeteer';
+import { Page } from 'puppeteer-core';
 import unzipper from 'unzipper';
 
 import { generateDirectoryStructure } from '@project/init';

--- a/platforms/tktrex/tt-automate/src/util/page.ts
+++ b/platforms/tktrex/tt-automate/src/util/page.ts
@@ -1,6 +1,6 @@
 import os from 'os';
 
-import puppeteerVanilla, { Page, Dialog } from 'puppeteer';
+import puppeteerVanilla, { Page, Dialog } from 'puppeteer-core';
 import puppeteer from 'puppeteer-extra';
 import stealth from 'puppeteer-extra-plugin-stealth';
 

--- a/platforms/tktrex/tt-automate/tsconfig.json
+++ b/platforms/tktrex/tt-automate/tsconfig.json
@@ -32,9 +32,9 @@
     "sourceMap": true
   },
   "references": [
-    { "path": "../../packages/shared" },
-    { "path": "../tktrex/shared" },
-    { "path": "../guardoni" }
+    { "path": "../../guardoni" },
+    { "path": "../../../packages/shared" },
+    { "path": "../shared" }
   ],
   "ts-node": {
     "require": ["tsconfig-paths/register"],


### PR DESCRIPTION
By removing the `puppeteer` dependency and using `puppeteer-extra` and `puppeteer-core` we should get rid of the local chromium version downloaded automatically by the package and rely only on the paths available on the user machine - like we do for production.

