### PR TITLE
fix(guardoni): fetch metadata after experiment in cli tests

### DIFF
--- a/.github/workflows/guardoni_pull_request.yml
+++ b/.github/workflows/guardoni_pull_request.yml
@@ -140,7 +140,9 @@ jobs:
 
       - name: Test YT cli
         working-directory: ./platforms/guardoni
-        run: ./scripts/cli-yt-test.mjs
+        run: |
+          ./scripts/cli-yt-test-home.mjs
+          ./scripts/cli-yt-test-videos.mjs
 
       - name: Stop PM2
         run: yarn pm2 stop all

--- a/.github/workflows/guardoni_pull_request.yml
+++ b/.github/workflows/guardoni_pull_request.yml
@@ -10,8 +10,8 @@ on:
       - fix/**
       - refactor/**
     paths:
-      - "packages/shared/**"
-      - "platforms/**"
+      - 'packages/shared/**'
+      - 'platforms/**'
 
 jobs:
   pull_request:
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-          cache: "yarn"
+          cache: 'yarn'
           cache-dependency-path: yarn.lock
 
       - name: Install modules
@@ -69,9 +69,6 @@ jobs:
   guardoni_build:
     name: Guardoni build
     runs-on: ${{ matrix.config.os }}
-    # defaults:
-    #   run:
-    #     shell: bash --noprofile --norc -exo pipefail {0}
     strategy:
       max-parallel: 1
       matrix:
@@ -138,11 +135,11 @@ jobs:
         working-directory: ./platforms/guardoni
         run: ./scripts/cli-build.mjs
 
-      - name: Test YT cli
-        working-directory: ./platforms/guardoni
-        run: |
-          ./scripts/cli-yt-test-home.mjs
-          ./scripts/cli-yt-test-videos.mjs
+      # - name: Test CLI - YT Home
+      #   run: yarn guardoni cli-yt-test-home
+
+      # - name: Test CLI - YT Videos
+      #   run: yarn guardoni cli-yt-test-videos
 
       - name: Stop PM2
         run: yarn pm2 stop all

--- a/packages/shared/src/providers/puppeteer/DirectiveHook.ts
+++ b/packages/shared/src/providers/puppeteer/DirectiveHook.ts
@@ -1,14 +1,12 @@
 import * as puppeteer from 'puppeteer-core';
 import { OpenURLDirective } from '../../models/Directive';
 
+type Hook = (page: puppeteer.Page, directive: any, opts?: any) => Promise<any>;
+
 export interface DirectiveHooks<
   DO extends string,
   CS extends {
-    [key: string]: (
-      page: puppeteer.Page,
-      directive: any,
-      opts?: any
-    ) => Promise<any>;
+    [key: string]: Hook;
   }
 > {
   openURL: {

--- a/platforms/guardoni/docs/development/test.md
+++ b/platforms/guardoni/docs/development/test.md
@@ -22,8 +22,10 @@ For this purpose there are two different scripts located at `platforms/guardoni/
 
 ```bash
 cd ./platforms/guardoni
-# run test for youtube platform
-./scripts/cli-yt-test.sh
+# run test for `platform` "youtube" and `type` "home"
+./scripts/cli-yt-test-home.mjs
+# run test for `platform` "youtube" and `type` "video"
+./scripts/cli-yt-test-videos.mjs
 # run test for titkok platform
 ./scripts/cli-tk-test.sh
 ```

--- a/platforms/guardoni/package.json
+++ b/platforms/guardoni/package.json
@@ -22,7 +22,9 @@
     "postinstall": "electron-builder install-app-deps",
     "prepack": "yarn build",
     "check-stealth": "ts-node ./bin/check-stealth.ts",
-    "tdd": "jest --watch --verbose"
+    "tdd": "jest --watch --verbose",
+    "cli-yt-test-videos": "node ./scripts/cli-yt-test-videos.mjs",
+    "cli-yt-test-home": "node ./scripts/cli-yt-test-home.mjs"
   },
   "bin": {
     "cli": "./bin/guardoni-cli.js"

--- a/platforms/guardoni/scripts/cli-yt-test-home.mjs
+++ b/platforms/guardoni/scripts/cli-yt-test-home.mjs
@@ -18,6 +18,7 @@ void (async function () {
   )}`;
   const flags = [
     '--basePath=./',
+    `--executablePath=${process.env.PUPPETEER_EXEC_PATH}`,
     '-c=guardoni.config.json',
     '--headless',
     '--verbose',
@@ -28,6 +29,9 @@ void (async function () {
     `--publicKey=${process.env.PUBLIC_KEY}`,
     `--secretKey=${process.env.SECRET_KEY}`,
   ];
+
+  // reject cookie modal
+  await $`${cli} ${flags} yt-navigate --cookie-modal=reject --exit --headless=false`;
 
   const yt_home_experiment_register_out =
     await $`${cli} ${flags}  yt-register ./experiments/yt-home.csv | grep 'experimentId: '`;

--- a/platforms/guardoni/scripts/cli-yt-test-videos.mjs
+++ b/platforms/guardoni/scripts/cli-yt-test-videos.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/* eslint-disable camelcase */
+
+import { $, os, fetch } from 'zx';
+import { normalizePlatform, getGuardoniCliPkgName } from './utils.mjs';
+import dotenv from 'dotenv';
+import assert from 'assert';
+
+dotenv.config({ path: '.env.development' });
+
+// eslint-disable-next-line no-void
+void (async function () {
+  const version = await $`node -p -e "require('./package.json').version"`;
+  const platform = normalizePlatform(os.type());
+  const cli = `./dist/${getGuardoniCliPkgName(
+    version.stdout.replace('\n', ''),
+    platform
+  )}`;
+  const flags = [
+    '--basePath=./',
+    '-c=guardoni.config.json',
+    '--headless',
+    '--verbose',
+  ];
+
+  const experimentFlags = [
+    ...flags,
+    `--publicKey=${process.env.PUBLIC_KEY}`,
+    `--secretKey=${process.env.SECRET_KEY}`,
+  ];
+
+  // // register an experiment for videos
+  const yt_video_experiment_register_out =
+    await $`${cli} ${flags} yt-register ./experiments/yt-videos.csv | grep 'experimentId: '`;
+  const yt_video_experiment_id = yt_video_experiment_register_out.stdout
+    .replace('experimentId: \t ', '')
+    .replace('\n', '');
+
+  await $`echo ${yt_video_experiment_id}`;
+
+  // exec the experiment
+  const ytVideoExperimentRunOut =
+    await $`(${cli} ${experimentFlags} yt-experiment ${yt_video_experiment_id} | grep 'publicKey: ')`;
+
+  await $`echo ${ytVideoExperimentRunOut}`;
+
+  const ytVideoExperimentPubKey = ytVideoExperimentRunOut.stdout
+    .replace('publicKey: \t ', '')
+    .replace('\n', '');
+
+  assert.strictEqual(ytVideoExperimentPubKey, process.env.PUBLIC_KEY);
+
+  const metadata = await fetch(
+    `http://localhost:9000/api/v2/metadata?experimentId=${yt_video_experiment_id}`
+  ).then((r) => r.json());
+
+  assert.strictEqual(metadata[0].experimentId, yt_video_experiment_id);
+  assert.strictEqual(metadata[0].type, 'video');
+  assert.strictEqual(metadata[1].experimentId, yt_video_experiment_id);
+  assert.strictEqual(metadata[1].type, 'video');
+  assert.strictEqual(metadata[2].experimentId, yt_video_experiment_id);
+  assert.strictEqual(metadata[2].type, 'video');
+})();

--- a/platforms/guardoni/scripts/cli-yt-test-videos.mjs
+++ b/platforms/guardoni/scripts/cli-yt-test-videos.mjs
@@ -18,6 +18,7 @@ void (async function () {
   )}`;
   const flags = [
     '--basePath=./',
+    `--executablePath=${process.env.PUPPETEER_EXEC_PATH}`,
     '-c=guardoni.config.json',
     '--headless',
     '--verbose',
@@ -28,6 +29,9 @@ void (async function () {
     `--publicKey=${process.env.PUBLIC_KEY}`,
     `--secretKey=${process.env.SECRET_KEY}`,
   ];
+
+  // reject cookie modal
+  await $`${cli} ${flags} yt-navigate --cookie-modal=reject --exit --headless=false`
 
   // // register an experiment for videos
   const yt_video_experiment_register_out =

--- a/platforms/guardoni/src/guardoni/browser.ts
+++ b/platforms/guardoni/src/guardoni/browser.ts
@@ -13,8 +13,8 @@ export const dispatchBrowser =
     const commandLineArg = [
       '--no-sandbox',
       '--disabled-setuid-sandbox',
-      '--load-extension=' + ctx.platform.extensionDir,
       '--disable-extensions-except=' + ctx.platform.extensionDir,
+      '--load-extension=' + ctx.platform.extensionDir,
     ];
 
     if (proxy) {

--- a/platforms/guardoni/src/guardoni/types.ts
+++ b/platforms/guardoni/src/guardoni/types.ts
@@ -5,6 +5,7 @@ import { APIClient } from '@shared/providers/api.provider';
 import { PuppeteerProvider } from '@shared/providers/puppeteer/puppeteer.provider';
 import * as t from 'io-ts';
 import { nonEmptyArray } from 'io-ts-types';
+import { DirectiveHooks } from '@shared/providers/puppeteer/DirectiveHook';
 
 export const Platform = t.union(
   [t.literal('youtube'), t.literal('tiktok')],
@@ -81,6 +82,7 @@ export type GuardoniProfile = t.TypeOf<typeof GuardoniProfile>;
 
 export interface GuardoniContext {
   puppeteer: PuppeteerProvider;
+  hooks: DirectiveHooks<string, any>;
   API: APIClient<typeof endpoints>;
   config: GuardoniConfig;
   platform: PlatformConfig;


### PR DESCRIPTION
This is the integration of the API for metadata ( #552 ) in guardoni, to be able to fetch the experiment results after execution.

This will enable @chobeat to proceed with Mbuto integration