### PR TITLE
fix(guardoni): cli navigation and platform's frontend assignment

### DIFF
--- a/platforms/guardoni/guardoni.config.json
+++ b/platforms/guardoni/guardoni.config.json
@@ -7,13 +7,13 @@
   "yt": {
     "name": "youtube",
     "backend": "http://localhost:9000/api",
-    "frontend": "http://localhost:1313/",
+    "frontend": "http://localhost:1313",
     "extensionDir": "../yttrex/extension/build"
   },
   "tk": {
     "name": "tiktok",
     "backend": "http://localhost:14000/api",
-    "frontend": "http://localhost:1313/",
+    "frontend": "http://localhost:1313",
     "extensionDir": "../tktrex/extension/build"
   },
   "chromePath": "/usr/bin/google-chrome"

--- a/platforms/guardoni/src/guardoni/cli.ts
+++ b/platforms/guardoni/src/guardoni/cli.ts
@@ -158,7 +158,7 @@ export const GetGuardoniCLI: GetGuardoniCLI = (
               return g.runExperiment(command.experiment, command.opts);
             case 'navigate': {
               return pipe(
-                g.runNavigate(command.opts),
+                g.runNavigate({ ...config, ...command.opts }),
                 TE.map(() => ({
                   type: 'success',
                   values: [],

--- a/platforms/guardoni/src/guardoni/config.ts
+++ b/platforms/guardoni/src/guardoni/config.ts
@@ -214,15 +214,16 @@ export const getPlatformConfig = (
 
   // ensure frontend always exists
   const frontend =
-    platformConf.frontend ?? platformConfigKey === 'tk'
-      ? DEFAULT_TK_FRONTEND
-      : DEFAULT_YT_FRONTEND;
+    platformConf.frontend ??
+    (platformConfigKey === 'tk' ? DEFAULT_TK_FRONTEND : DEFAULT_YT_FRONTEND);
 
-  return {
+  const pConfig = {
     ...platformConf,
     extensionDir,
     frontend,
   };
+
+  return pConfig;
 };
 
 export const setConfig = (


### PR DESCRIPTION
Here I fixed a couple of small issues in guardoni:
- check if `hooks.custom.cookieModal` exists before calling it during "navigate"
- correct platform frontend's config computation
- additional config for `yt-navigate` and `tk-navigate` to override the `headless` option