### PR TITLE
fix(guardoni): delete extension cache

### DIFF
--- a/platforms/guardoni/docs/cli/usage.md
+++ b/platforms/guardoni/docs/cli/usage.md
@@ -115,3 +115,18 @@ when:
 publicKey:       XXX-your-public-key-XXX
 
 ```
+
+### Clean the extension dir
+
+```bash
+guardoni-cli yt-clean
+
+# output
+
+guardoni:info Using profile default +0ms
+guardoni:info Cleaning extension dir /home/ascariandrea/.guardoni/extension/yt +11ms
+
+
+Clean succeeded: Extension dir cleaned
+
+```

--- a/platforms/guardoni/src/guardoni/cli.ts
+++ b/platforms/guardoni/src/guardoni/cli.ts
@@ -39,6 +39,10 @@ export interface GuardoniNavigateOpts extends GuardoniCommandOpts {
   exit?: boolean;
 }
 
+export interface GuardoniCleanOpts {
+  platform: Platform;
+}
+
 export type GuardoniCommandConfig =
   | {
       run: 'register-csv';
@@ -59,6 +63,9 @@ export type GuardoniCommandConfig =
   | {
       run: 'navigate';
       opts: GuardoniNavigateOpts;
+    }
+  | {
+      run: 'clean';
     };
 
 export interface GuardoniCLI {
@@ -177,6 +184,16 @@ export const GetGuardoniCLI: GetGuardoniCLI = (
                 }))
               );
             }
+            case 'clean':
+              return pipe(
+                g.cleanExtension(),
+                TE.map(() => ({
+                  type: 'success',
+                  values: [],
+                  message: 'Extension dir cleaned',
+                }))
+              );
+
             case 'auto':
             default:
               return g.runAuto(command.value);
@@ -403,6 +420,18 @@ const program = yargs(hideBin(process.argv))
     }
   )
   .command(
+    'yt-clean',
+    'Clean YT extension',
+    (yargs) => yargs,
+    (argv) => {
+      void runGuardoni({
+        ...argv,
+        platform: 'youtube',
+        command: { run: 'clean' },
+      });
+    }
+  )
+  .command(
     'tk-navigate',
     'Use guardoni browser with loaded tk extension',
     (yargs) =>
@@ -470,7 +499,7 @@ const program = yargs(hideBin(process.argv))
         demandOption: 'Provide a valid path to a csv file',
       });
     },
-    ({ file, ...argv }) => {
+    ({ file, $0, _, ...argv }) => {
       void runGuardoni({
         ...argv,
         platform: 'tiktok',
@@ -481,14 +510,24 @@ const program = yargs(hideBin(process.argv))
   .command(
     'tk-list',
     'List available experiments',
-    (yargs) => {
-      return yargs;
-    },
+    (yargs) => yargs,
     (argv) => {
       void runGuardoni({
         ...argv,
         platform: 'tiktok',
         command: { run: 'list' },
+      });
+    }
+  )
+  .command(
+    'tk-clean',
+    'Clean TK extension',
+    (yargs) => yargs,
+    (argv) => {
+      void runGuardoni({
+        ...argv,
+        platform: 'tiktok',
+        command: { run: 'clean' },
       });
     }
   )

--- a/platforms/guardoni/src/guardoni/experiment.ts
+++ b/platforms/guardoni/src/guardoni/experiment.ts
@@ -222,16 +222,16 @@ export const registerExperiment =
     );
   };
 
+export const getExperimentJSONPath = (ctx: GuardoniContext): string =>
+  path.join(ctx.platform.extensionDir, 'experiment.json');
+
 export const saveExperiment =
   (ctx: GuardoniContext) =>
   (
     experimentId: NonEmptyString,
     profile: GuardoniProfile
   ): TE.TaskEither<AppError, ExperimentInfo> => {
-    const experimentJSONFile = path.join(
-      ctx.platform.extensionDir,
-      'experiment.json'
-    );
+    const experimentJSONPath = getExperimentJSONPath(ctx);
 
     const experimentInfo = {
       experimentId,
@@ -243,14 +243,14 @@ export const saveExperiment =
 
     ctx.logger.debug(
       'Saving experiment info in %s to be read by the extension %O',
-      experimentJSONFile,
+      experimentJSONPath,
       experimentInfo
     );
 
     return pipe(
       liftFromIOE(() =>
         fs.writeFileSync(
-          experimentJSONFile,
+          experimentJSONPath,
           JSON.stringify(experimentInfo),
           'utf-8'
         )

--- a/platforms/guardoni/src/guardoni/extension.ts
+++ b/platforms/guardoni/src/guardoni/extension.ts
@@ -49,11 +49,21 @@ export const downloadExtension = (
         const httpPerms = m.permissions.filter((p: string) =>
           p.startsWith('http')
         );
-        ctx.logger.info(
-          `Manifest found, no need to download the extension: %s (%O)`,
-          m.version,
-          httpPerms
-        );
+
+        if (m.version === ctx.version) {
+          ctx.logger.info(
+            `Manifest found, no need to download the extension: %s (%O)`,
+            m.version,
+            httpPerms
+          );
+        } else {
+          ctx.logger.warn(
+            'WARNING: Manifest found, but extension version mismatch: %s (guardoni %s)',
+            m.version,
+            ctx.version
+          );
+        }
+
         return undefined;
       }
 

--- a/platforms/guardoni/src/guardoni/guardoni.ts
+++ b/platforms/guardoni/src/guardoni/guardoni.ts
@@ -422,7 +422,7 @@ export const GetGuardoni: GetGuardoni = ({
 }) => {
   const loggerSpaces = verbose
     ? ['guardoni*', '@trex*', process.env.DEBUG]
-    : ['guardoni:info', 'guardoni:error', process.env.DEBUG];
+    : ['guardoni:info', 'guardoni:warn', 'guardoni:error', process.env.DEBUG];
 
   debug.enable(loggerSpaces.join(','));
 

--- a/platforms/guardoni/src/guardoni/guardoni.ts
+++ b/platforms/guardoni/src/guardoni/guardoni.ts
@@ -38,7 +38,11 @@ import {
   saveExperiment,
   validateNonEmptyString,
 } from './experiment';
-import { downloadExtension, setLocalSettings } from './extension';
+import {
+  downloadExtension,
+  setLocalSettings,
+  cleanExtension,
+} from './extension';
 import {
   checkProfile,
   getDefaultProfile,
@@ -69,7 +73,8 @@ const runNavigate =
         : 'https://www.youtube.com';
 
     return pipe(
-      TE.right(setLocalSettings(ctx)(opts)),
+      downloadExtension(ctx),
+      TE.map(() => setLocalSettings(ctx)(opts)),
       TE.chain(() =>
         dispatchBrowser(ctx)({
           headless: opts?.headless !== undefined ? opts.headless : true,
@@ -130,7 +135,8 @@ export const runBrowser =
     opts?: GuardoniCommandOpts
   ): TE.TaskEither<AppError, ExperimentInfo & { publicKey: string | null }> => {
     return pipe(
-      dispatchBrowser(ctx)({}),
+      downloadExtension(ctx),
+      TE.chain(() => dispatchBrowser(ctx)({})),
       TE.chain((browser) => {
         return TE.tryCatch(async () => {
           const [page, ...otherPages] = await browser.pages();
@@ -166,6 +172,7 @@ export const runExperiment =
     );
     return pipe(
       TE.fromEither(validateNonEmptyString(experimentId)),
+      TE.chainFirst(() => downloadExtension(ctx)),
       TE.chain((expId) =>
         sequenceS(TE.ApplicativePar)({
           profile: updateGuardoniProfile(ctx)(
@@ -206,6 +213,7 @@ export const runExperimentForPage =
   ): TE.TaskEither<AppError, GuardoniSuccessOutput> =>
     pipe(
       getDirective(ctx)(experimentId),
+      TE.chainFirst(() => downloadExtension(ctx)),
       TE.chain((data) => guardoniExecution(ctx)(experimentId, data, page)),
       TE.map((publicKey) => ({
         type: 'success',
@@ -350,8 +358,7 @@ const loadContext = (
         E.mapLeft(toAppError),
         TE.fromEither
       );
-    }),
-    TE.chainFirst(downloadExtension)
+    })
   );
 };
 
@@ -378,6 +385,10 @@ export interface Guardoni {
     onProgress?: (details: ProgressDetails) => void
   ) => TE.TaskEither<AppError, GuardoniSuccessOutput>;
   runNavigate: (opts?: GuardoniCommandOpts) => TE.TaskEither<AppError, void>;
+  /**
+   * Clean the extension directory
+   */
+  cleanExtension: () => TE.TaskEither<AppError, void>;
 }
 
 interface GuardoniLauncher {
@@ -434,6 +445,7 @@ export const GetGuardoni: GetGuardoni = ({
             registerExperimentFromCSV: registerCSV(ctx),
             listExperiments: listExperiments(ctx),
             runNavigate: runNavigate(ctx),
+            cleanExtension: cleanExtension(ctx),
           };
         })
       );
@@ -446,13 +458,14 @@ export const GetGuardoni: GetGuardoni = ({
             config: ctx.config,
             platform: ctx.platform,
             API: ctx.API,
-            runAuto: runAuto(ctx),
-            runExperiment: runExperiment(ctx),
-            runExperimentForPage: runExperimentForPage(ctx),
             registerExperiment: registerExperiment(ctx),
             registerExperimentFromCSV: registerCSV(ctx),
             listExperiments: listExperiments(ctx),
             runNavigate: runNavigate(ctx),
+            runAuto: runAuto(ctx),
+            runExperiment: runExperiment(ctx),
+            runExperimentForPage: runExperimentForPage(ctx),
+            cleanExtension: cleanExtension(ctx),
           };
         })
       );

--- a/platforms/guardoni/src/guardoni/profile.ts
+++ b/platforms/guardoni/src/guardoni/profile.ts
@@ -95,7 +95,7 @@ export const checkProfile =
 
     const profile = JSON.parse(fs.readFileSync(profileFile, 'utf-8'));
 
-    ctx.logger.debug('Returning profile %s', profileName);
+    ctx.logger.info('Using profile %s', profileName);
 
     return TE.right(profile);
   };


### PR DESCRIPTION
In order to download updated version of the extension we need to clear the directory where guardoni stores the extension.
Here's an handy command to achieve this: `guardoni-cli yt-clean` (or `guardoni-cli tk-clean`)