### PR TITLE
fix(shared): defined puppeteer hooks for keypress and click

### DIFF
--- a/packages/shared/src/models/Step.ts
+++ b/packages/shared/src/models/Step.ts
@@ -14,6 +14,23 @@ export const ScrollStep = t.strict(
 );
 export type ScrollStep = t.TypeOf<typeof ScrollStep>;
 
+export const KeyPressType = t.literal('keypress');
+export const KeypressStep = t.strict(
+  {
+    type: KeyPressType,
+    key: t.string,
+    times: t.union([t.number, t.undefined]),
+    delay: t.union([t.number, t.undefined]),
+    text: t.union([t.string, t.undefined]),
+  },
+  'KeypressStep'
+);
+// this is an hack to avoid a compile error due to
+// key [string] not being compatible with [puppeteer.KeyInput]
+export type KeypressStep = Omit<t.TypeOf<typeof KeypressStep>, 'key'> & {
+  key: puppeteer.KeyInput;
+};
+
 export const CustomStepType = t.literal('custom');
 export type CustomStepType = t.TypeOf<typeof CustomStepType>;
 
@@ -36,8 +53,9 @@ export const OpenURLStep = t.strict(
     title: t.union([t.string, t.undefined]),
     url: t.string,
     urltag: t.union([t.string, t.undefined]),
-    watchFor: t.union([ t.number, t.string, t.undefined]),
+    watchFor: t.union([t.number, t.string, t.undefined]),
     loadFor: t.union([t.number, t.string, t.undefined]),
+    onCompleted: t.union([t.string, t.undefined]),
   },
 
   'OpenURLStep'
@@ -46,7 +64,7 @@ export const OpenURLStep = t.strict(
 export type OpenURLStep = t.TypeOf<typeof OpenURLStep>;
 
 export const Step = t.union(
-  [ScrollStep, CustomStep, OpenURLStep],
+  [ScrollStep, CustomStep, KeypressHook, OpenURLStep],
   'OpenURL'
 );
 export type Step = t.TypeOf<typeof Step>;

--- a/packages/shared/src/models/Step.ts
+++ b/packages/shared/src/models/Step.ts
@@ -31,6 +31,18 @@ export type KeypressStep = Omit<t.TypeOf<typeof KeypressStep>, 'key'> & {
   key: puppeteer.KeyInput;
 };
 
+export const ClickType = t.literal('click');
+export const ClickStep = t.strict(
+  {
+    type: ClickType,
+    selector: t.string,
+    delay: t.union([t.number, t.undefined]),
+  },
+  'ClickStep'
+);
+
+export type ClickStep = t.TypeOf<typeof ClickStep>;
+
 export const CustomStepType = t.literal('custom');
 export type CustomStepType = t.TypeOf<typeof CustomStepType>;
 
@@ -64,7 +76,15 @@ export const OpenURLStep = t.strict(
 export type OpenURLStep = t.TypeOf<typeof OpenURLStep>;
 
 export const Step = t.union(
-  [ScrollStep, CustomStep, KeypressHook, OpenURLStep],
+  [
+    ScrollStep,
+    CustomStep,
+    KeypressStep,
+    ClickStep,
+    // since `openURL` step is the default and the `type` can be `undefined`
+    // the `OpenURLStep` codec needs to be the last value of the union
+    OpenURLStep,
+  ],
   'OpenURL'
 );
 export type Step = t.TypeOf<typeof Step>;

--- a/packages/shared/src/providers/puppeteer/StepHooks.ts
+++ b/packages/shared/src/providers/puppeteer/StepHooks.ts
@@ -1,5 +1,5 @@
 import * as puppeteer from 'puppeteer-core';
-import { OpenURLStep } from '../../models/Step';
+import { Step } from '../../models/Step';
 
 type Hook = (page: puppeteer.Page, step: any, opts?: any) => Promise<any>;
 export interface StepHooks<
@@ -10,19 +10,10 @@ export interface StepHooks<
 > {
   openURL: {
     beforeDirectives: (page: puppeteer.Page) => Promise<void>;
-    beforeLoad: (
-      page: puppeteer.Page,
-      step: OpenURLStep
-    ) => Promise<void>;
-    beforeWait: (
-      page: puppeteer.Page,
-      step: OpenURLStep
-    ) => Promise<void>;
-    afterWait: (
-      page: puppeteer.Page,
-      step: OpenURLStep
-    ) => Promise<void>;
-    completed: () => Promise<string>;
+    beforeLoad: (page: puppeteer.Page, step: Step) => Promise<void>;
+    beforeWait: (page: puppeteer.Page, step: Step) => Promise<void>;
+    afterWait: (page: puppeteer.Page, step: Step) => Promise<void>;
+    completed: (page: puppeteer.Page, s: Step) => Promise<string>;
   };
   customs?: CS;
   DOMAIN_NAME: DO;

--- a/packages/shared/src/providers/puppeteer/puppeteer.provider.ts
+++ b/packages/shared/src/providers/puppeteer/puppeteer.provider.ts
@@ -9,6 +9,7 @@ import {
   Step,
   ScrollStepType,
   KeyPressType,
+  ClickType,
 } from '../../models/Step';
 // import { throwTE } from '../../utils/task.utils';
 import { StepHooks } from './StepHooks';
@@ -16,6 +17,7 @@ import { openURL } from './steps/openURL';
 import { GetScrollFor } from './steps/scroll';
 import StealthPlugin from 'puppeteer-extra-plugin-stealth';
 import { GetKeypressStep } from './steps/keyPress';
+import { GetClickStep } from './steps/click';
 
 export type LaunchOptions = puppeteer.LaunchOptions &
   puppeteer.BrowserLaunchArgumentOptions &
@@ -58,6 +60,9 @@ const operateTab =
       }
       case KeyPressType.value: {
         return GetKeypressStep(ctx)(page, h as any);
+      }
+      case ClickType.value: {
+        return GetClickStep(ctx)(page, h);
       }
       case CustomStepType.value:
         return TE.tryCatch(() => {

--- a/packages/shared/src/providers/puppeteer/steps/click.ts
+++ b/packages/shared/src/providers/puppeteer/steps/click.ts
@@ -1,0 +1,53 @@
+import * as E from 'fp-ts/lib/Either';
+import * as TE from 'fp-ts/lib/TaskEither';
+import * as puppeteer from 'puppeteer-core';
+import { AppError, toAppError } from '../../../errors/AppError';
+import { ClickStep } from '../../../models/Step';
+import { sleep } from '../../../utils/promise.utils';
+import { StepContext } from './types';
+
+/**
+ * Click command REgExp
+ *
+ * click('video')
+ */
+export const CLICK_COMMAND_REGEXP =
+  // eslint-disable-next-line no-useless-escape
+  /click\(([#|\.]?[\w|:|\s|\.|\-]+);(\d+)\)/gm;
+
+export const parseClickCommand = (
+  cmd: string
+): E.Either<AppError, { selector: string; delay: number }> => {
+  const match = CLICK_COMMAND_REGEXP.exec(cmd);
+  // console.log(match);
+  if (match?.[1] && match[2]) {
+    const selector: any = match[1];
+    const delay = parseInt(match[2], 10);
+    return E.right({ selector, delay });
+  }
+  return E.left(
+    new AppError('ClickStepError', `Cannot parse command: ${cmd}`, [])
+  );
+};
+/**
+ * Click step
+ *
+ * Click an element by the given selector
+ *
+ */
+
+export const GetClickStep =
+  (ctx: StepContext) =>
+  (
+    page: puppeteer.Page,
+    { selector, delay: _delay }: ClickStep
+  ): TE.TaskEither<AppError, void> => {
+    const delay = _delay ?? 0;
+
+    return TE.tryCatch(async () => {
+      ctx.logger.debug('Click %s with delay %d', selector, delay);
+      const el = await page.waitForSelector(selector, { timeout: 0 });
+      await el?.click();
+      await sleep(2000);
+    }, toAppError);
+  };

--- a/packages/shared/src/providers/puppeteer/steps/keyPress.ts
+++ b/packages/shared/src/providers/puppeteer/steps/keyPress.ts
@@ -1,0 +1,61 @@
+import * as A from 'fp-ts/lib/Array';
+import * as E from 'fp-ts/lib/Either';
+import { pipe } from 'fp-ts/lib/function';
+import * as T from 'fp-ts/lib/Task';
+import * as TE from 'fp-ts/lib/TaskEither';
+import * as puppeteer from 'puppeteer-core';
+import { AppError, toAppError } from '../../../errors/AppError';
+import { KeypressStep } from '../../../models/Step';
+import { sleep } from '../../../utils/promise.utils';
+import { StepContext } from './types';
+
+export const KEYPRESS_COMMAND_REGEXP = /keypress\((\w+);(\d+);(\d+)\)/g;
+
+export const parseKeypressCommand = (
+  cmd: string
+): E.Either<AppError, { key: puppeteer.KeyInput; times: number }> => {
+  const match = KEYPRESS_COMMAND_REGEXP.exec(cmd);
+  // console.log(match);
+  if (match?.[1] && match[2]) {
+    const key: any = match[1];
+    const times = parseInt(match[2], 10);
+    const delay = parseInt(match[3], 10);
+    return E.right({ key, times, delay });
+  }
+  return E.left(
+    new AppError('KeypressStepError', `Cannot parse command: ${cmd}`, [])
+  );
+};
+/**
+ * Step with type `scroll`
+ *
+ * Scroll page with an increment of `incrementScrollBy` until it reaches `totalScroll`
+ *
+ */
+
+export const GetKeypressStep =
+  (ctx: StepContext) =>
+  (
+    page: puppeteer.Page,
+    { times, key, delay: _delay, ...opts }: KeypressStep
+  ): TE.TaskEither<AppError, void> => {
+    const delay = _delay ?? 0;
+
+    return pipe(
+      A.sequence(T.ApplicativeSeq)(
+        Array.from({ length: times === undefined ? 1 : times }).map(
+          (_, i): T.Task<void> =>
+            () =>
+              sleep(delay)
+                .then(() => page.keyboard.press(key, opts))
+                .then((r) => {
+                  ctx.logger.debug('Key %s pressed for the %d times', key, i);
+                  return undefined;
+                })
+        )
+      ),
+      TE.fromTask,
+      TE.mapLeft(toAppError),
+      TE.map(() => undefined)
+    );
+  };

--- a/packages/shared/src/providers/puppeteer/steps/openURL.ts
+++ b/packages/shared/src/providers/puppeteer/steps/openURL.ts
@@ -53,19 +53,19 @@ export const openURL =
       // different parameters. https://stackoverflow.com/questions/60051954/puppeteer-timeouterror-navigation-timeout-of-30000-ms-exceeded
       try {
         await page.goto(step.url, {
-          waitUntil: 'networkidle0',
+          waitUntil: 'domcontentloaded',
           timeout: 20000,
         });
       } catch (e) {
-        ctx.logger.error('Error during goto %O (networkidle0)', e);
+        ctx.logger.error('Error during goto %O (domcontentloaded)', e);
 
         try {
+          ctx.logger.debug('Try to reach %s without timeout', step.url);
           await page.goto(step.url, {
-            waitUntil: ['domcontentloaded'],
-            timeout: 10000,
+            timeout: 0,
           });
         } catch (e) {
-          ctx.logger.error('Error during goto %O (docontentloaded)', e);
+          ctx.logger.error('Error during goto %O', e);
           throw e;
         }
       }

--- a/packages/shared/src/providers/puppeteer/steps/scroll.ts
+++ b/packages/shared/src/providers/puppeteer/steps/scroll.ts
@@ -1,3 +1,4 @@
+import { pipe } from 'fp-ts/lib/function';
 import * as TE from 'fp-ts/lib/TaskEither';
 import type * as puppeteer from 'puppeteer-core';
 import { AppError, toAppError } from '../../../errors/AppError';
@@ -32,31 +33,38 @@ async function autoScroll(
 export const GetScrollFor =
   (ctx: StepContext) =>
   (page: puppeteer.Page, step: ScrollStep): TE.TaskEither<AppError, void> => {
-    return TE.tryCatch(
-      async () =>
-        new Promise((resolve, reject) => {
-          let i = 0;
-          ctx.logger.debug('Start scrolling: %O', step);
-          const timer = setInterval(() => {
-            ctx.logger.debug('Running for time %d', i);
+    return pipe(
+      TE.tryCatch(
+        async () =>
+          new Promise((resolve, reject) => {
+            let i = 0;
+            ctx.logger.debug('Start scrolling: %O', step);
+            const timer = setInterval(() => {
+              ctx.logger.debug('Running for time %d', i);
 
-            void autoScroll(page, step).then(() => {
-              ctx.logger.debug('Scrolled by %d', i * step.incrementScrollByPX);
+              void autoScroll(page, step)
+                .then(() => {
+                  ctx.logger.debug(
+                    'Scrolled by %d',
+                    i * step.incrementScrollByPX
+                  );
 
-              if (step.totalScroll < i * step.incrementScrollByPX) {
-                ctx.logger.debug(
-                  'Scroll total reached: %d (%d)',
-                  i * step.incrementScrollByPX,
-                  step.totalScroll
-                );
-                clearInterval(timer);
-                resolve(undefined);
-              }
+                  if (step.totalScroll < i * step.incrementScrollByPX) {
+                    ctx.logger.debug(
+                      'Scroll total reached: %d (%d)',
+                      i * step.incrementScrollByPX,
+                      step.totalScroll
+                    );
+                    clearInterval(timer);
+                    resolve(undefined);
+                  }
 
-              i++;
-            }).catch(reject);
-          }, step.interval ?? 2000);
-        }),
-      toAppError
+                  i++;
+                })
+                .catch(reject);
+            }, step.interval ?? 2000);
+          }),
+        toAppError
+      )
     );
   };

--- a/platforms/guardoni/src/electron/tabs/FromURLsTab.tsx
+++ b/platforms/guardoni/src/electron/tabs/FromURLsTab.tsx
@@ -159,6 +159,7 @@ export const FromURLsTab: React.FC<FromCSVFileTabProps> = ({
                   urltag: newURLTag,
                   watchFor: newWatchFor,
                   loadFor: undefined,
+                  onCompleted: undefined,
                 }),
               });
             }

--- a/platforms/guardoni/src/guardoni/steps/tk.steps.ts
+++ b/platforms/guardoni/src/guardoni/steps/tk.steps.ts
@@ -1,3 +1,4 @@
+import { Step } from '@shared/models/Step';
 import { StepHooks } from '@shared/providers/puppeteer/StepHooks';
 import * as puppeteer from 'puppeteer-core';
 import { GuardoniProfile } from '../types';
@@ -39,7 +40,7 @@ async function beforeLoad(page: puppeteer.Page, directive: any): Promise<any> {
   return Promise.resolve();
 }
 
-async function completed(): Promise<string> {
+async function completed(page: puppeteer.Page, step: Step): Promise<string> {
   return globalConfig.publicKeySpot as string;
 }
 


### PR DESCRIPTION
This PR adds the possibility to define an additional column in the experiment csv named `onCompleted`.

The value given to this column is - possibly - a concatenation of actions which are, for now, `keypress` and `click`:

- `keypress(ArrowDown;5;5000)`: press `ArrowDown` with `5000`ms of delay for `5` times
- `click(video;0)`: click element by selector `video` with delay `0`ms

The concatenation can be achieved by using the delimiter ` - `, i.e. `click(.my-button;0) - keypress(ArrowUp;1;1000) - click(video;1000)`

The syntax of this command use the `;` as separator cause the `,` would break the csv - but it can be discussed.

Here's a sample csv you can you to test it:

```csv
url,urltag,loadFor,watchFor,type,incrementScrollByPX,totalScroll,onCompleted
https://www.tiktok.com/foryou,,,,openURL,600,1600,click(video;0) - keypress(ArrowDown;5;4000)
```



Small improvements have been made also for the `scoll` step and the `waitUntil` strategy for the `page.goto`

