### PR TITLE
refactor(shared): parser provider compatible with browser environment

### DIFF
--- a/packages/shared/src/providers/__tests__/parser.provider.spec.ts
+++ b/packages/shared/src/providers/__tests__/parser.provider.spec.ts
@@ -36,6 +36,8 @@ const Contribution = t.type(
   'Contribution'
 );
 
+type Contribution = t.TypeOf<typeof Contribution>;
+
 const { savingTime, ...ContributionTypeProps } = Contribution.props;
 
 const ContributionArb = getArbitrary(t.type({ ...ContributionTypeProps })).map(
@@ -55,6 +57,8 @@ const Metadata = t.type({
   savingTime: date,
 });
 
+type Metadata = t.TypeOf<typeof Metadata>;
+
 const { savingTime: _savingTime, ...metadataProps } = Metadata.props;
 const MetadataArb = getArbitrary(t.type({ ...metadataProps })).map((c) => {
   return {
@@ -64,11 +68,7 @@ const MetadataArb = getArbitrary(t.type({ ...metadataProps })).map((c) => {
 });
 
 describe('Parser Provider', () => {
-  const providerCtx: ParserProviderContext<
-    typeof Contribution,
-    typeof Metadata,
-    any
-  > = {
+  const providerCtx: ParserProviderContext<Contribution, Metadata, any, any> = {
     db: db as any,
     parsers: {
       home: homeParser,
@@ -87,6 +87,9 @@ describe('Parser Provider', () => {
     },
     buildMetadata,
     saveResults: saveResults,
+    config: {
+      downloads: '/download/here',
+    },
   };
 
   afterEach(() => {
@@ -108,6 +111,7 @@ describe('Parser Provider', () => {
     const output = payloadToTableOutput<
       typeof Contribution,
       typeof Metadata,
+      any,
       { [key: string]: any }
     >(
       (s) => s.id,
@@ -214,7 +218,11 @@ describe('Parser Provider', () => {
       backInTime: 0,
     });
 
-    expect(homeParser).toHaveBeenCalledWith(sources[0], {});
+    expect(homeParser).toHaveBeenCalledWith(
+      sources[0],
+      {},
+      { downloads: '/download/here' }
+    );
 
     expect(saveResults).toHaveBeenCalledWith(sources[0], metadata);
 

--- a/packages/shared/src/test/utils/parser.utils.ts
+++ b/packages/shared/src/test/utils/parser.utils.ts
@@ -56,7 +56,8 @@ export const runParserTest =
   <
     S extends t.Mixed,
     M extends t.Mixed,
-    PP extends Record<string, ParserFn<t.TypeOf<S>, any>>
+    C,
+    PP extends Record<string, ParserFn<t.TypeOf<S>, any, C>>
   >({
     codecs,
     expectMetadata,
@@ -74,7 +75,7 @@ export const runParserTest =
       expected: Array<t.TypeOf<M> & { _id: string }>
     ) => void;
     expectSources: (s: Array<t.TypeOf<S>>) => void;
-  } & ParserProviderContext<S, M, PP>) =>
+  } & ParserProviderContext<t.TypeOf<S>, t.TypeOf<M>, C, PP>) =>
   async ({ sources, metadata }: any) => {
     // opts.log.debug('Sources %d', sources.length);
 
@@ -85,7 +86,7 @@ export const runParserTest =
       sources.map((s: any) => s.html)
     );
 
-    const result = await parseContributions<S, M, PP>({ codecs, ...opts })({
+    const result = await parseContributions<S, M, C, PP>({ codecs, ...opts })({
       overflow: false,
       errors: 0,
       sources,

--- a/platforms/tktrex/backend/bin/parser.ts
+++ b/platforms/tktrex/backend/bin/parser.ts
@@ -10,9 +10,10 @@ import {
   buildMetadata,
   getLastHTMLs,
   HTMLSource,
-  updateMetadataAndMarkHTML
+  updateMetadataAndMarkHTML,
 } from '../lib/parser';
 import { parsers } from '../parsers';
+import { tkParserConfig } from '../parsers/config';
 
 nconf.argv().env().file({ file: 'config/settings.json' });
 
@@ -73,7 +74,7 @@ const run = async (): Promise<void> => {
       db,
       codecs: {
         contribution: HTMLSource,
-        metadata: TKMetadata
+        metadata: TKMetadata,
       },
       parsers,
       getContributions: getLastHTMLs(db),
@@ -82,6 +83,7 @@ const run = async (): Promise<void> => {
       buildMetadata,
       getEntryDate: (e) => e.html.savingTime,
       getEntryNatureType: (e) => e.html.type,
+      config: tkParserConfig,
     }).run({
       singleUse: typeof id === 'string' ? id : false,
       filter,

--- a/platforms/tktrex/backend/parsers/__tests__/native.e2e.ts
+++ b/platforms/tktrex/backend/parsers/__tests__/native.e2e.ts
@@ -86,6 +86,7 @@ describe('Parser: "native"', () => {
           getEntryNatureType: (e) => e.html.type,
           getContributions: getLastHTMLs(db),
           saveResults: updateMetadataAndMarkHTML(db),
+          config: {},
           expectSources: (receivedSources) => {
             receivedSources.forEach((s) => {
               expect((s as any).processed).toBe(true);

--- a/platforms/tktrex/backend/parsers/config.ts
+++ b/platforms/tktrex/backend/parsers/config.ts
@@ -1,0 +1,9 @@
+import nconf from 'nconf';
+
+export interface TKParserConfig {
+  downloads?: string;
+}
+
+export const tkParserConfig = {
+  downloads: nconf.get('downloads'),
+};

--- a/platforms/tktrex/backend/parsers/metrics.ts
+++ b/platforms/tktrex/backend/parsers/metrics.ts
@@ -1,8 +1,12 @@
 import { ParserFn } from '@shared/providers/parser.provider';
 import { HTMLSource } from '../lib/parser';
 import { Metrics } from '@tktrex/shared/models/Metadata';
+import { TKParserConfig } from './config';
 
-const metrics: ParserFn<HTMLSource, Metrics> = async (envelop, previous) => {
+const metrics: ParserFn<HTMLSource, Metrics, TKParserConfig> = async (
+  envelop,
+  previous
+) => {
   /* 2.4.x 'foryou' and 'following' are considered only */
   const availin = ['foryou', 'following', 'video', 'native'];
 

--- a/platforms/tktrex/backend/parsers/native.ts
+++ b/platforms/tktrex/backend/parsers/native.ts
@@ -1,10 +1,11 @@
 import { ParserFn } from '@shared/providers/parser.provider';
 import D from 'debug';
 import { HTMLSource } from '../lib/parser';
+import { TKParserConfig } from './config';
 
 const debug = D('parser:native');
 
-const parseNativeVideo: ParserFn<HTMLSource, any> = async (
+const parseNativeVideo: ParserFn<HTMLSource, any, TKParserConfig> = async (
   envelop,
   findings
 ) => {

--- a/platforms/tktrex/backend/parsers/nature.ts
+++ b/platforms/tktrex/backend/parsers/nature.ts
@@ -1,9 +1,13 @@
 import { ParserFn } from '@shared/providers/parser.provider';
 import { Nature } from '@tktrex/shared/models/Nature';
 import { HTMLSource } from '../lib/parser';
+import { TKParserConfig } from './config';
 import { getNatureByHref } from './shared';
 
-const nature: ParserFn<HTMLSource, Nature> = async (envelop, previous) => {
+const nature: ParserFn<HTMLSource, Nature, TKParserConfig> = async (
+  envelop,
+  previous
+) => {
   /* this parser is meant to analye the URL
    * and understand which kind of nature has this html */
   return getNatureByHref(envelop.html.href);

--- a/platforms/tktrex/backend/parsers/shared.ts
+++ b/platforms/tktrex/backend/parsers/shared.ts
@@ -6,13 +6,11 @@ import {
   Nature,
   ProfileN,
   SearchN,
-  VideoN,
 } from '@tktrex/shared/models/Nature';
 import D from 'debug';
-import _ from 'lodash';
-import nconf from 'nconf';
-import fetch from 'node-fetch';
 import fs from 'fs';
+import _ from 'lodash';
+import fetch from 'node-fetch';
 import path from 'path';
 
 const debug = D('parsers:shared');
@@ -75,19 +73,19 @@ export function getNatureByHref(href: string): Nature | null {
   }
 }
 
-export function getUUID(url: string, type: any): any {
+export function getUUID(url: string, type: any, dir: string): any {
   const ui = new URL(url);
   const fullpath = ui.pathname;
   const fname = path.basename(fullpath);
   const fullname = type === 'video' ? `${fname}.mp4` : `${fname}.jpeg`;
   const cwd = process.cwd();
-  if (!nconf.get('downloads')) {
-    /* eslint-disable no-console */
-    console.log("WRONG CONFIGURATION SETTINGS!! missing 'downloads' from", cwd);
-    process.exit(1);
-  }
+  // if (!nconf.get('downloads')) {
+  //   /* eslint-disable no-console */
+  //   console.log("WRONG CONFIGURATION SETTINGS!! missing 'downloads' from", cwd);
+  //   process.exit(1);
+  // }
   const initials = fname.substr(0, 2);
-  const destdir = path.join(cwd, nconf.get('downloads'), type, initials);
+  const destdir = path.join(cwd, dir, type, initials);
   if (!fs.existsSync(destdir)) {
     try {
       fs.mkdirSync(destdir, { recursive: true });

--- a/platforms/tktrex/backend/routes/__tests__/personal.e2e.ts
+++ b/platforms/tktrex/backend/routes/__tests__/personal.e2e.ts
@@ -26,35 +26,40 @@ let keys: Keypair;
 describe('/v2/personal', () => {
   let appTest: Test;
   const [experiment] = fc.sample(GuardoniExperimentArb, 1);
-  let parserProvider: ParserProvider<HTMLSource, TKMetadata, typeof parsers> =
-    beforeAll(async () => {
-      appTest = await GetTest();
-      await appTest.mongo3.insertMany(
-        appTest.mongo,
-        appTest.config.get('schema').experiments,
-        [experiment]
-      );
-      keys = await foldTEOrThrow(bs58.makeKeypair(''));
-      const db = {
-        write: appTest.mongo,
-        read: appTest.mongo,
-        api: appTest.mongo3,
-      };
-      parserProvider = GetParserProvider('html', {
-        db,
-        parsers: parsers,
-        codecs: {
-          contribution: HTMLSource,
-          metadata: TKMetadata,
-        },
-        getEntryId: (e) => e.html.id,
-        getContributions: getLastHTMLs(db),
-        getEntryDate: (e) => e.html.savingTime,
-        getEntryNatureType: (e) => e.html.type,
-        buildMetadata: buildMetadata,
-        saveResults: updateMetadataAndMarkHTML(db),
-      });
+  let parserProvider: ParserProvider<
+    HTMLSource,
+    TKMetadata,
+    any,
+    typeof parsers
+  > = beforeAll(async () => {
+    appTest = await GetTest();
+    await appTest.mongo3.insertMany(
+      appTest.mongo,
+      appTest.config.get('schema').experiments,
+      [experiment]
+    );
+    keys = await foldTEOrThrow(bs58.makeKeypair(''));
+    const db = {
+      write: appTest.mongo,
+      read: appTest.mongo,
+      api: appTest.mongo3,
+    };
+    parserProvider = GetParserProvider('html', {
+      db,
+      config: {},
+      parsers: parsers,
+      codecs: {
+        contribution: HTMLSource,
+        metadata: TKMetadata,
+      },
+      getEntryId: (e) => e.html.id,
+      getContributions: getLastHTMLs(db),
+      getEntryDate: (e) => e.html.savingTime,
+      getEntryNatureType: (e) => e.html.type,
+      buildMetadata: buildMetadata,
+      saveResults: updateMetadataAndMarkHTML(db),
     });
+  });
 
   afterAll(async () => {
     await appTest.mongo.close();

--- a/platforms/yttrex/backend/bin/leaves-parser.ts
+++ b/platforms/yttrex/backend/bin/leaves-parser.ts
@@ -13,6 +13,7 @@ import * as mongo3 from '@shared/providers/mongo.provider';
 import { GetParserProvider } from '@shared/providers/parser.provider';
 import { leafParsers } from '../parsers';
 import { Ad } from '@yttrex/shared/models/Ad';
+import { parserConfig } from '../parsers/config';
 
 nconf.argv().env().file({ file: 'config/settings.json' });
 
@@ -78,6 +79,7 @@ const run = async (): Promise<void> => {
       getEntryNatureType: (e) => e.html.nature.type,
       buildMetadata: toMetadata,
       saveResults: updateAdvertisingAndMetadata(db),
+      config: parserConfig,
     }).run({
       singleUse: typeof id === 'string' ? id : false,
       filter,

--- a/platforms/yttrex/backend/bin/parser.ts
+++ b/platforms/yttrex/backend/bin/parser.ts
@@ -13,6 +13,7 @@ import {
 import { GetParserProvider } from '@shared/providers/parser.provider';
 import { parsers } from '../parsers';
 import { Metadata } from '@yttrex/shared/models/Metadata';
+import { parserConfig } from '../parsers/config';
 
 nconf.argv().env().file({ file: 'config/settings.json' });
 
@@ -82,6 +83,7 @@ const run = async (): Promise<void> => {
       getEntryNatureType: (e) => e.html.nature.type,
       buildMetadata: toMetadata,
       saveResults: updateMetadataAndMarkHTML(db),
+      config: parserConfig,
     }).run({
       singleUse: typeof id === 'string' ? id : false,
       filter,

--- a/platforms/yttrex/backend/parsers/config.ts
+++ b/platforms/yttrex/backend/parsers/config.ts
@@ -1,0 +1,9 @@
+import nconf from 'nconf';
+
+export interface YTParserConfig {
+  downloads?: string;
+}
+
+export const parserConfig = {
+  downloads: nconf.get('NO_DOWNLOAD'),
+};

--- a/platforms/yttrex/backend/parsers/home.ts
+++ b/platforms/yttrex/backend/parsers/home.ts
@@ -4,6 +4,7 @@ import { HomeMetadata, ParsedInfo } from '@yttrex/shared/models/Metadata';
 import _ from 'lodash';
 import moment from 'moment';
 import { HTMLSource } from '../lib/parser/html';
+import { YTParserConfig } from './config';
 import * as longlabel from './longlabel';
 import * as shared from './shared';
 import uxlang from './uxlang';
@@ -359,9 +360,11 @@ function guessUXLanguage(D: Document): string | null {
   return uxlang.findLanguage('video', localizedStrings);
 }
 
-export const processHome: ParserFn<HTMLSource, HomeMetadata> = async (
-  envelop
-) => {
+export const processHome: ParserFn<
+  HTMLSource,
+  HomeMetadata,
+  YTParserConfig
+> = async (envelop) => {
   const retval: HomeMetadata = {
     id: '',
     type: 'home',

--- a/platforms/yttrex/backend/parsers/leaf.ts
+++ b/platforms/yttrex/backend/parsers/leaf.ts
@@ -6,6 +6,7 @@ import D from 'debug';
 import { LeafSource } from 'lib/parser/leaf';
 import _ from 'lodash';
 import moment from 'moment';
+import { YTParserConfig } from './config';
 
 const leafLogger = D('leaf');
 const leafLogD = leafLogger.extend('debug');
@@ -185,7 +186,9 @@ export const allowedSelectors = Object.keys(leafSelectors).filter(
 //   'searchAds',
 // ];
 
-export const processLeaf: ParserFn<LeafSource, Ad> = async (e) => {
+export const processLeaf: ParserFn<LeafSource, Ad, YTParserConfig> = async (
+  e
+) => {
   // e is the 'element', it comes from the DB, and we'll look the
   // e.html mostly. different e.selecotrName causes different sub-functions
   if (!allowedSelectors.includes(e.html.selectorName)) {

--- a/platforms/yttrex/backend/parsers/nature.ts
+++ b/platforms/yttrex/backend/parsers/nature.ts
@@ -1,14 +1,13 @@
 import { ParserFn } from '@shared/providers/parser.provider';
 import { HTMLSource } from '../lib/parser/html';
 import { Nature } from '../models/Nature';
+import { YTParserConfig } from './config';
 import processHome from './home';
 import { processSearch } from './searches';
 import parseVideo from './video';
 
 const processNature =
-  (
-    type: Nature['type']
-  ): ParserFn<HTMLSource, any> =>
+  (type: Nature['type']): ParserFn<HTMLSource, any, YTParserConfig> =>
   (e, findings, ctx) => {
     switch (type) {
       case 'video':
@@ -27,7 +26,7 @@ const processNature =
  *
  *
  */
-export const nature: ParserFn<HTMLSource, Nature> = async (
+export const nature: ParserFn<HTMLSource, Nature, YTParserConfig> = async (
   e,
   findings,
   ctx

--- a/platforms/yttrex/backend/parsers/nature.ts
+++ b/platforms/yttrex/backend/parsers/nature.ts
@@ -1,31 +1,39 @@
 import { ParserFn } from '@shared/providers/parser.provider';
 import { HTMLSource } from '../lib/parser/html';
-import processHome from './home';
-import parseVideo from './video';
-import { processSearch } from './searches';
 import { Nature } from '../models/Nature';
+import processHome from './home';
+import { processSearch } from './searches';
+import parseVideo from './video';
 
-const processNature = (type: Nature['type'], e: HTMLSource): any => {
-  switch (type) {
-    case 'video':
-      return parseVideo(e);
-    case 'search':
-      return processSearch(e);
-    case 'home':
-      return processHome(e);
-    default:
-      throw new Error(`Nature ${type} not handled.`);
-  }
-};
+const processNature =
+  (
+    type: Nature['type']
+  ): ParserFn<HTMLSource, any> =>
+  (e, findings, ctx) => {
+    switch (type) {
+      case 'video':
+        return parseVideo(e, findings, ctx);
+      case 'search':
+        return processSearch(e, findings, ctx);
+      case 'home':
+        return processHome(e, findings, ctx);
+      default:
+        throw new Error(`Nature ${type} not handled.`);
+    }
+  };
 
 /**
  * Extract the nature from given entry.
  *
  *
  */
-export const nature: ParserFn<HTMLSource, Nature> = async (e) => {
+export const nature: ParserFn<HTMLSource, Nature> = async (
+  e,
+  findings,
+  ctx
+) => {
   const type = e.html.nature.type ?? (e.html as any).type;
-  const nature = await processNature(type, e);
+  const nature = await processNature(type)(e, findings, ctx);
   if (!nature) {
     throw new Error('No nature found for this entry.');
   }

--- a/platforms/yttrex/backend/parsers/searches.ts
+++ b/platforms/yttrex/backend/parsers/searches.ts
@@ -3,6 +3,7 @@ import { formatDistanceToNow, subSeconds } from 'date-fns';
 import D from 'debug';
 import _ from 'lodash';
 import { HTMLSource } from '../lib/parser/html';
+import { YTParserConfig } from './config';
 import * as longlabel from './longlabel';
 
 const debuge = D('parser:searches:error');
@@ -123,9 +124,11 @@ function unpackCorrection(corelem): string[] {
   return _.compact(_.flatten(_.map(corelem.children, unpackCorrection)));
 }
 
-export const processSearch: ParserFn<HTMLSource, any | null> = async (
-  envelop
-) => {
+export const processSearch: ParserFn<
+  HTMLSource,
+  any | null,
+  YTParserConfig
+> = async (envelop) => {
   /* this function process a page like:
     https://www.youtube.com/results?search_query=fingerprinting
        and the logic here is: look for any video, and then move above 

--- a/platforms/yttrex/backend/parsers/thumbnail.ts
+++ b/platforms/yttrex/backend/parsers/thumbnail.ts
@@ -2,10 +2,10 @@ import { ParserFn } from '@shared/providers/parser.provider';
 import fs from 'fs';
 import { HTMLSource } from 'lib/parser/html';
 import _ from 'lodash';
-import nconf from 'nconf';
 import fetch from 'node-fetch';
 import path from 'path';
 import D from 'debug';
+import { YTParserConfig } from './config';
 
 const debug = D('parsers:thumbnail');
 /* if(!nconf.get('thumbnails')) {
@@ -73,10 +73,12 @@ async function downloadFromVideoId(videoIds: string[]): Promise<any[]> {
   return retval;
 }
 
-const conditionalDownload: ParserFn<HTMLSource, any> = async ({
-  html: entry,
-}) => {
-  if (nconf.get('NO_DOWNLOAD')) {
+const conditionalDownload: ParserFn<HTMLSource, any, YTParserConfig> = async (
+  { html: entry },
+  prev,
+  config
+) => {
+  if (config.downloads) {
     debug('Thumbnail disabled by nconf variable!');
     return null;
   }

--- a/platforms/yttrex/backend/parsers/video.ts
+++ b/platforms/yttrex/backend/parsers/video.ts
@@ -11,6 +11,7 @@ import * as longlabel from './longlabel';
 import * as shared from './shared';
 import uxlang from './uxlang';
 import { ParserFn } from '@shared/providers/parser.provider';
+import { YTParserConfig } from './config';
 
 const videoLog = trexLogger.extend('video');
 
@@ -480,9 +481,11 @@ export function processVideo(
     viewInfo,
     likeInfo,
   } as any;
-};
+}
 
-const parseVideo: ParserFn<HTMLSource, VideoMetadata> = async (envelop) => {
+const parseVideo: ParserFn<HTMLSource, VideoMetadata, YTParserConfig> = async (
+  envelop
+) => {
   let extracted: VideoMetadata;
 
   try {

--- a/platforms/yttrex/backend/routes/__tests__/personal.e2e.ts
+++ b/platforms/yttrex/backend/routes/__tests__/personal.e2e.ts
@@ -11,6 +11,7 @@ import { Ad } from '@yttrex/shared/models/Ad';
 import { Metadata } from '@yttrex/shared/models/Metadata';
 import { pipe } from 'fp-ts/lib/function';
 import * as fs from 'fs';
+import { parserConfig } from '../../parsers/config';
 import * as path from 'path';
 import {
   getLastHTMLs,
@@ -120,6 +121,7 @@ describe('Events', () => {
         buildMetadata: toAdMetadata,
         getEntryNatureType: (e) => e.html.nature.type,
         saveResults: updateAdvertisingAndMetadata(db),
+        config: parserConfig,
       }).run({
         singleUse: true,
         stop: 1,
@@ -142,6 +144,7 @@ describe('Events', () => {
         saveResults: updateMetadataAndMarkHTML(db),
         getEntryDate: (e) => e.html.savingTime,
         getEntryNatureType: (e) => e.html.nature.type,
+        config: parserConfig,
       }).run({
         singleUse: true,
         stop: 1,


### PR DESCRIPTION
I added another field to pass to the `GetParserProvider` named `config` that is passed down to the `ParserFn`.
In this way we can pass from the outside variables like `nconf.get('downloads')` to change the parser behavior.