### PR TITLE
chore(workspace): extension reviewer install from zip and build flow

### DIFF
--- a/.github/workflows/daily_release.yml
+++ b/.github/workflows/daily_release.yml
@@ -42,6 +42,11 @@ jobs:
           DEBUG: "@trex*,@YCAI*"
         run: yarn ycai build
 
+      - name: Shrink to zip
+        run: |
+          ./scripts/shrink.sh
+          ./scripts/install-from-shrinkzip.sh ./build/trex.zip ../trex-shrink-test
+
       - name: Release Version
         run: yarn release-it --no-github.release --release-version
 

--- a/scripts/install-from-shrinkzip.sh
+++ b/scripts/install-from-shrinkzip.sh
@@ -1,22 +1,27 @@
 #!/usr/bin/bash
 
-set -x
+set -ex
 
 # This script is necessary to produce the .zip files to submit to mozilla store
 # Otherwise the repo is too big
 
-out=../trex-from-zip
+from=${1:-build/trex.zip}
+out=${2:-./build}
 
 mkdir -p $out
 
 # cp ./build/trex.zip $out/
 
-unzip -o -d $out build/trex.zip
+unzip -o -d $out $from
 
 cd $out || exit
 
 yarn install
 
-yarn tk:ext build
-yarn yt:ext build
+yarn tk:ext dist
+ls -l platforms/tktrex/extension/dist/*.zip
+yarn yt:ext dist
+ls -l platforms/yttrex/extension/dist/*.zip
 yarn ycai build
+ls -l platforms/ycai/studio/build/extension/*.zip
+

--- a/scripts/shrink.sh
+++ b/scripts/shrink.sh
@@ -21,9 +21,13 @@ mkdir -p build;
 #    exit;
 # fi
 
+suffix=$('grep version package.json  | sed -es/.*:// | sed -es/[\ \",]//g')
+fileout="build/trex${suffix}.zip"
+echo "zipping in $fileout"
+
 # this is the biggest cache
-echo "Removing .yarn/cache"
-# rm -rf .yarn/cache
+echo "Remove previous zip"
+rm build/trex*.zip
 
 # this should not be present anyways
 echo "Removing node_modules"
@@ -34,18 +38,27 @@ echo "Removing test files and unnecessary folders"
 # rm -rf platforms/*/backend
 
 echo "Creating new version of README for extension reviewer"
-echo -e "### Extension reviewer TODOs\n\n    yarn\n    yarn tk:ext dist\n    ls -l platforms/tktrex/extension/dist/*.zip\n    yarn yt:ext dist\n    ls -l platforms/yttrex/extension/dist/*.zip\n    yarn ycai build\n    ls -l platforms/ycai/studio/build/extension/*.zip\n\n" > README.md
-echo "tktrex is tiktok.tracking.exposed extension" >> README.md
-echo "yttrex is youtube.tracking.exposed extension" >> README.md
-echo "ycai is youchoose.ai extension" >> README.md
+echo -e "## Extension reviewer TODOs\n\n" > TODO.md
+echo -e 'Place the `trex.zip` in a folder an unzip it \n' >> TODO.md
+echo -e "### Requirements\n" >> TODO.md
+echo -e '- yarn `v3`\n - node `16` \n' >>  TODO.md
+echo -e "#### Automatic installation\n" >> TODO.md
+echo -e '```bash\n./scripts/install-from-shrinkzip.sh ./trex.zip ./\n```\n' >> TODO.md
+echo -e "#### Manual installation \n" >> TODO.md
+echo -e 'Install dependencies\n' >> TODO.md
+echo -e '```bash\nyarn\n```\n' >> TODO.md
+echo -e "tktrex is tiktok.tracking.exposed extension\n" >> TODO.md
+echo -e '```bash\nyarn tk:ext dist\nls -l platforms/tktrex/extension/dist/*.zip\n```\n' >> TODO.md
+echo -e "yttrex is youtube.tracking.exposed extension\n" >> TODO.md
+echo -e '```bash\nyarn yt:ext dist\nls -l platforms/yttrex/extension/dist/*.zip\n```\n' >> TODO.md
+echo -e "ycai is youchoose.ai extension\n" >> TODO.md
+echo -e '```bash\nyarn ycai build\nls -l platforms/ycai/studio/build/extension/*.zip\n```\n' >> TODO.md
 
-suffix=$('grep version package.json  | sed -es/.*:// | sed -es/[\ \",]//g')
-fileout="build/trex${suffix}.zip"
-echo "zipping in $fileout"
+mv README.md .README.md
+mv TODO.md README.md
 
 zip $fileout -r ./* \
-  .npmrc .nvmrc .yarn .yarnrc.yml  \
-  -x "yarn.lock" \
+  .npmrc .nvmrc .yarn .yarnrc.yml \
   -x ".yarn/unplugged/**" \
   -x ".yarn/cache/**" \
   -x ".vscode/**" \
@@ -58,10 +71,16 @@ zip $fileout -r ./* \
   -x "coverage/**" -x "**/coverage/**" \
   -x "docker/**" \
   -x "build/**" -x "**/build/**" \
+  -x "scripts/**" -x "**/scripts/**" \
   -x "platforms/guardoni/**" \
   -x "platforms/tktrex/observatory/**" \
   -x "platforms/tktrex/ua-observatory/**" \
   -x "platforms/tktrex/tt-automate/**" \
-  -x "platforms/*/backend/**" \
+  -x "platforms/*/backend/**"
+
+zip $fileout scripts/install-from-shrinkzip.sh
+
+rm README.md
+mv .README.md README.md
 
 echo "done!"


### PR DESCRIPTION
I fixed the `zip` creation for extension review submission by including the `yarn.lock` in the output.

I also defined a step in the CI to test this flow everytime we merge on daily.

🎉 


