### PR TITLE
fix(yt:shared): search, home and video route handlers

### DIFF
--- a/packages/shared/src/extension/app.ts
+++ b/packages/shared/src/extension/app.ts
@@ -148,21 +148,26 @@ function setupObserver(
               const handler = handlers[h];
 
               if (handler.match.type === 'route') {
-                appLog.debug(
-                  'Matching route %O',
-                  handler.match,
-                  window.location.pathname
-                );
+                // appLog.debug(
+                //   'Matching route %O',
+                //   handler.match,
+                //   window.location.pathname
+                // );
                 return window.location.pathname.match(handler.match.location);
               }
               return false;
             });
 
             if (routeHandlerKey) {
-              appLog.debug('Route handler key %s', routeHandlerKey);
               const { handle, ...routeHandlerOpts } = handlers[
                 routeHandlerKey
               ] as RouteObserverHandler;
+              appLog.debug(
+                'Matched route handler key %s: %O',
+                routeHandlerKey,
+                routeHandlerOpts
+              );
+
               handle(window.document.body, routeHandlerOpts, routeHandlerKey, {
                 ...config,
                 href: window.location.toString(),

--- a/packages/shared/src/extension/utils/HTMLSize.utils.ts
+++ b/packages/shared/src/extension/utils/HTMLSize.utils.ts
@@ -1,0 +1,68 @@
+import { trexLogger } from '../../logger';
+import * as _ from 'lodash';
+
+const logger = trexLogger.extend('html-size');
+
+/**
+ * Check html size
+ *
+ * @param nodeHTML html string to send as contribution
+ * @returns true when html increased since last time
+ */
+export function sizeCheck(prev: number, curr: number): boolean {
+  // this is the minimum size worthy of reporting
+  if (curr < 100000) {
+    logger.debug('HTML too small to consider!', curr);
+    return false;
+  }
+
+  // check if the increment is more than 4%, otherwise is not interesting
+  const percentile = 100 / curr;
+  const percentage = _.round(100 - percentile * prev, 2);
+
+  logger.info(
+    'HTML size (%d) difference since last observed size +%d %',
+    curr,
+    prev
+  );
+
+  if (percentage < 5) {
+    logger.debug(
+      `Skipping update as ${percentage}% of the page is already sent (size ${curr}, lastObservedSize ${prev}) ${window.location.pathname}`
+    );
+    return false;
+  }
+
+  logger.info(
+    `Valid update as a new %d% of the page have been received (size %d, lastObservedSize %d) %s`,
+    percentage,
+    curr,
+    prev,
+    window.location.pathname
+  );
+  return true;
+}
+
+export interface HTMLSize {
+  check: (html: string) => boolean;
+  reset: () => void;
+}
+
+export const HTMLSize = (): HTMLSize => {
+  let lastSize = 1;
+  return {
+    check: (html) => {
+      // this function look at the LENGTH of the proposed element.
+      // this is used in video because the full html body page would be too big.
+      const s = _.size(html);
+      if (!sizeCheck(lastSize, s)) {
+        return false;
+      }
+      lastSize = s;
+      return true;
+    },
+    reset: () => {
+      lastSize = 1;
+    },
+  };
+};

--- a/platforms/yttrex/backend/__tests__/parser/html/parseVideo.e2e.ts
+++ b/platforms/yttrex/backend/__tests__/parser/html/parseVideo.e2e.ts
@@ -8,6 +8,7 @@ import {
 } from '@shared/test/utils/parser.utils';
 import { VideoMetadata } from '@yttrex/shared/models/Metadata';
 import { HTMLSource, parsers } from '@yttrex/shared/parser';
+import { toMetadata } from '@yttrex/shared/parser/metadata';
 import base58 from 'bs58';
 import { addMinutes, parseISO } from 'date-fns';
 import path from 'path';
@@ -21,7 +22,6 @@ import {
   getSourceSchema,
   updateMetadataAndMarkHTML,
 } from '../../../lib/parser/html';
-import { toMetadata } from '@yttrex/shared/parser/metadata';
 
 describe('Parser: Video', () => {
   let appTest: Test;

--- a/platforms/yttrex/backend/lib/utils.js
+++ b/platforms/yttrex/backend/lib/utils.js
@@ -5,7 +5,6 @@ const bs58 = require('bs58');
 const nacl = require('tweetnacl');
 const nconf = require('nconf');
 const foodWords = require('food-words');
-const url = require('url');
 
 function hash(obj, fields) {
   if (_.isUndefined(fields)) fields = _.keys(obj);
@@ -172,50 +171,6 @@ function judgeIncrement(key, current, value) {
   debug('Unexpected kind? %s %j %j', key, current, value);
 }
 
-function getNatureFromURL(href) {
-  // this function MUST support the different URLs
-  // format specify in ../../extension/src/consideredURLs.js
-  const uq = new url.URL(href);
-  if (uq.pathname === '/results') {
-    const searchTerms = uq.searchParams.get('search_query');
-    return {
-      type: 'search',
-      query: searchTerms,
-    };
-  } else if (uq.pathname === '/watch') {
-    const videoId = uq.searchParams.get('v');
-    return {
-      type: 'video',
-      videoId,
-    };
-  } else if (uq.pathname === '/') {
-    return {
-      type: 'home',
-    };
-  } else if (_.startsWith(uq.pathname, '/hashtag')) {
-    const hashtag = uq.pathname.split('/').pop();
-    return {
-      type: 'hashtag',
-      hashtag,
-    };
-  } else if (
-    _.startsWith(uq.pathname, '/channel') ||
-    _.startsWith(uq.pathname, '/user') ||
-    _.startsWith(uq.pathname, '/c')
-  ) {
-    const authorSource = uq.pathname.split('/').pop();
-    return {
-      type: 'channel',
-      authorSource,
-    };
-  } else {
-    debug('Unknow condition: %s', uq.href);
-    return {
-      type: 'unknown',
-    };
-  }
-}
-
 module.exports = {
   hash,
   activeUserCount,
@@ -229,5 +184,4 @@ module.exports = {
   parseIntNconf,
   prettify,
   judgeIncrement,
-  getNatureFromURL,
 };

--- a/platforms/yttrex/backend/routes/events.js
+++ b/platforms/yttrex/backend/routes/events.js
@@ -1,4 +1,5 @@
 import { geo } from '@shared/utils/ip.utils';
+import { getNatureFromURL } from '@yttrex/shared/parser/parsers/nature';
 
 const _ = require('lodash');
 const debug = require('debug')('routes:events');
@@ -235,7 +236,7 @@ async function processEvents2(req) {
      * get rid of these filters, the issue was the presence of 'info' entry
      * fail in extracting a size and more likely a collision was happening */
     function (body, i) {
-      const nature = utils.getNatureFromURL(body.href);
+      const nature = getNatureFromURL(body.href);
       const metadataId = utils.hash({
         publicKey: headers.publickey,
         randomUUID: body.randomUUID,
@@ -272,7 +273,7 @@ async function processEvents2(req) {
   );
 
   const leaves = _.map(_.filter(req.body, { type: 'leaf' }), function (e, i) {
-    const nature = utils.getNatureFromURL(e.href);
+    const nature = getNatureFromURL(e.href);
     const metadataId = utils.hash({
       publicKey: headers.publickey,
       randomUUID: e.randomUUID,

--- a/platforms/yttrex/extension/src/app/app.ts
+++ b/platforms/yttrex/extension/src/app/app.ts
@@ -35,7 +35,10 @@ import logger from '@shared/extension/logger';
 import UserSettings from '@shared/extension/models/UserSettings';
 import { sizeCheck } from '@shared/providers/dataDonation.provider';
 import { hasVideosInBody } from '@yttrex/shared/parser/parsers/searches';
-import { mineAuthorInfo } from '@yttrex/shared/parser/parsers/video';
+import {
+  getVideoTitle,
+  mineAuthorInfo,
+} from '@yttrex/shared/parser/parsers/video';
 import {
   consideredURLs,
   leafSelectors,
@@ -310,16 +313,19 @@ export const handleRoute = (
     return;
   }
 
-  hub.dispatch({
-    type: 'NewVideo',
-    payload: {
-      type: urlkind,
-      element: sendableNode.outerHTML,
-      size: sendableNode.outerHTML.length,
-      href: window.location.href,
-      randomUUID: feedId,
-    },
-  });
+  // check is a valid "video" nature
+  if (getVideoTitle(document) && mineAuthorInfo(document)) {
+    hub.dispatch({
+      type: 'NewVideo',
+      payload: {
+        type: urlkind,
+        element: sendableNode.outerHTML,
+        size: sendableNode.outerHTML.length,
+        href: window.location.href,
+        randomUUID: feedId,
+      },
+    });
+  }
 
   updateUI('video.send');
 };

--- a/platforms/yttrex/shared/src/models/Nature.ts
+++ b/platforms/yttrex/shared/src/models/Nature.ts
@@ -31,5 +31,16 @@ export const ChannelN = t.strict(
   'ChannelN'
 );
 
-export const Nature = t.union([HomeN, SearchN, VideoN, ChannelN], 'Nature');
+export const HashtagN = t.strict(
+  {
+    type: t.literal('hashtag'),
+    hashtag: t.string,
+  },
+  'HashtagNature'
+);
+
+export const Nature = t.union(
+  [HomeN, SearchN, VideoN, ChannelN, HashtagN],
+  'Nature'
+);
 export type Nature = t.TypeOf<typeof Nature>;

--- a/platforms/yttrex/shared/src/parser/parsers/uxlang.js
+++ b/platforms/yttrex/shared/src/parser/parsers/uxlang.js
@@ -268,6 +268,11 @@ const localizedFirstButton = [
     first: 'Suchen',
     iso2: 'de',
   },
+  {
+    type: 'video',
+    first: 'Salta link di navigazione',
+    iso2: 'it',
+  },
 ];
 
 function findLanguage(type, chunks) {

--- a/platforms/yttrex/shared/src/parser/parsers/video.ts
+++ b/platforms/yttrex/shared/src/parser/parsers/video.ts
@@ -68,8 +68,8 @@ function parseLikes(D: Document): likesParser.Likes {
   const nodes = D.querySelectorAll(
     '.ytd-toggle-button-renderer > yt-formatted-string'
   );
-  const likes = nodes[0].getAttribute('aria-label');
-  const dislikes = nodes[1].getAttribute('aria-label');
+  const likes = nodes[0]?.getAttribute('aria-label');
+  const dislikes = nodes[1]?.getAttribute('aria-label');
   const likeInfo = {
     likes,
     dislikes,
@@ -303,7 +303,7 @@ export function parseSingleTry(D: Document, memo: any, spec: any): any {
   }
 }
 
-function manyTries(D: Document, opportunities): any {
+function manyTries(D: Document, opportunities: any[]): string | null {
   const r = _.reduce(opportunities, _.partial(parseSingleTry, D), null);
   videoLog.debug('manyTries: %j: %s', _.map(opportunities, 'name'), r);
   return r;
@@ -381,15 +381,10 @@ export function simpleTitlePicker(D: Document, blang: string): string | null {
   return null;
 }
 
-export function processVideo(
-  D: Document,
-  blang: string,
-  clientTime: Date,
-  urlinfo?: URL
-): VideoMetadata {
+export const getVideoTitle = (D: Document): string | null => {
   /* this method to extract title was a nice experiment
    * and/but should be refactored and upgraded */
-  let title = manyTries(D, [
+  return manyTries(D, [
     {
       name: 'title h1',
       selector: 'h1 > yt-formatted-string',
@@ -405,6 +400,15 @@ export function processVideo(
       func: 'textContent',
     },
   ]);
+};
+
+export function processVideo(
+  D: Document,
+  blang: string,
+  clientTime: Date,
+  urlinfo?: URL
+): VideoMetadata {
+  let title = getVideoTitle(D);
 
   if (!title) title = simpleTitlePicker(D, blang);
 


### PR DESCRIPTION
Improved the yt video parsing with:
- check for `title` and `author` info existence for the data contribution before sending
- prevent parsing failure when `likes` info not available