### PR TITLE
fix(yt:backend): metadata api filter by nature

### DIFF
--- a/platforms/yttrex/backend/routes/__tests__/metadata.e2e.ts
+++ b/platforms/yttrex/backend/routes/__tests__/metadata.e2e.ts
@@ -7,12 +7,12 @@ jest.mock('fetch-opengraph');
 import { fc } from '@shared/test';
 import moment from 'moment';
 import _ from 'lodash';
-import { v4 as uuid } from 'uuid';
 import {
   ParsedInfoArb,
   VideoMetadataArb,
 } from '../../tests/arbitraries/Metadata.arb';
 import { GetTest, Test } from '../../tests/Test';
+import * as utils from '../../lib/utils';
 
 describe('Metadata API', () => {
   let test: Test;
@@ -64,9 +64,11 @@ describe('Metadata API', () => {
         )
         .sort((a, b) => b.savingTime.getTime() - a.savingTime.getTime())
         .slice(0, amount)
-        .map((m) => {
+        .map(({ publicKey, _id, ...m }: any) => {
           return {
             ...m,
+            id: m.id.substring(0, 20),
+            supporter: utils.string2Food(publicKey),
             clientTime: m.clientTime.toISOString(),
             publicationTime: m.publicationTime.toISOString(),
             savingTime: m.savingTime.toISOString(),
@@ -110,11 +112,13 @@ describe('Metadata API', () => {
       const experimentId = fc.sample(fc.uuid(), 1)[0];
       const amount = 10;
 
-      const metadata = fc.sample(VideoMetadataArb, 100).map((m) => ({
-        ...m,
-        savingTime: new Date(),
-        experimentId,
-      }));
+      const metadata = fc
+        .sample(VideoMetadataArb, 100)
+        .map((m) => ({
+          ...m,
+          savingTime: new Date(),
+          experimentId,
+        }));
 
       await test.mongo3.insertMany(
         test.mongo,
@@ -130,9 +134,11 @@ describe('Metadata API', () => {
         )
         .sort((a, b) => b.savingTime.getTime() - a.savingTime.getTime())
         .slice(0, amount)
-        .map((m) => {
+        .map(({ publicKey, _id, ...m }: any) => {
           return {
             ...m,
+            id: m.id.substring(0, 20),
+            supporter: utils.string2Food(publicKey),
             clientTime: m.clientTime.toISOString(),
             publicationTime: m.publicationTime.toISOString(),
             savingTime: m.savingTime.toISOString(),

--- a/platforms/yttrex/backend/routes/metadata.ts
+++ b/platforms/yttrex/backend/routes/metadata.ts
@@ -14,6 +14,8 @@ const PUBLIC_AMOUNT_ELEMS = 100;
 const listMetadata = async (req: Express.Request): Promise<any> => {
   const {
     query: {
+      publicKey,
+      nature,
       experimentId,
       researchTag,
       amount = PUBLIC_AMOUNT_ELEMS,
@@ -22,7 +24,13 @@ const listMetadata = async (req: Express.Request): Promise<any> => {
     },
   } = endpoints.decodeOrThrowRequest(v2.Metadata.ListMetadata, req);
 
-  const filter = {} as any;
+  const filter = {
+    publicKey,
+  } as any;
+  if (nature) {
+    filter.type = nature;
+  }
+
   if (experimentId) {
     filter.experimentId = experimentId;
   }

--- a/platforms/yttrex/shared/src/endpoints/v2/metadata.endpoints.ts
+++ b/platforms/yttrex/shared/src/endpoints/v2/metadata.endpoints.ts
@@ -1,6 +1,7 @@
 import { Format } from '@shared/models/common';
 import * as t from 'io-ts';
 import { NumberFromString } from 'io-ts-types/lib/NumberFromString';
+import { NatureType } from '../../models/Nature';
 import { Endpoint } from 'ts-endpoint';
 import { MetadataList } from '../../models/Metadata';
 
@@ -9,6 +10,8 @@ const ListMetadata = Endpoint({
   getPath: () => `/v2/metadata`,
   Input: {
     Query: t.type({
+      publicKey: t.string,
+      nature: t.union([NatureType, t.undefined]),
       experimentId: t.union([t.string, t.undefined]),
       researchTag: t.union([t.string, t.undefined]),
       amount: t.union([NumberFromString, t.undefined]),

--- a/platforms/yttrex/shared/src/endpoints/v2/metadata.endpoints.ts
+++ b/platforms/yttrex/shared/src/endpoints/v2/metadata.endpoints.ts
@@ -10,7 +10,7 @@ const ListMetadata = Endpoint({
   getPath: () => `/v2/metadata`,
   Input: {
     Query: t.type({
-      publicKey: t.string,
+      publicKey: t.union([t.string, t.undefined]),
       nature: t.union([NatureType, t.undefined]),
       experimentId: t.union([t.string, t.undefined]),
       researchTag: t.union([t.string, t.undefined]),

--- a/platforms/yttrex/shared/src/models/Nature.ts
+++ b/platforms/yttrex/shared/src/models/Nature.ts
@@ -1,43 +1,63 @@
 import * as t from 'io-ts';
 
+const HomeNatureType = t.literal('home');
+
 export const HomeN = t.strict(
   {
-    type: t.literal('home'),
+    type: HomeNatureType,
   },
   'HomeNature'
 );
 
+export const SearchNatureType = t.literal('search');
+
 export const SearchN = t.strict(
   {
-    type: t.literal('search'),
+    type: SearchNatureType,
     query: t.string,
   },
   'SearchNature'
 );
 
+export const VideoNatureType = t.literal('video');
 export const VideoN = t.strict(
   {
-    type: t.literal('video'),
+    type: VideoNatureType,
     videoId: t.string,
   },
   'VideoNature'
 );
 
+export const ChannelNatureType = t.literal('channel');
+
 export const ChannelN = t.strict(
   {
-    type: t.literal('channel'),
+    type: ChannelNatureType,
     authorSource: t.string,
   },
   'ChannelN'
 );
 
+export const HashtagNatureType = t.literal('hashtag');
 export const HashtagN = t.strict(
   {
-    type: t.literal('hashtag'),
+    type: HashtagNatureType,
     hashtag: t.string,
   },
   'HashtagNature'
 );
+
+export const NatureType = t.union(
+  [
+    HomeNatureType,
+    SearchNatureType,
+    VideoNatureType,
+    ChannelNatureType,
+    HashtagNatureType,
+  ],
+  'NatureType'
+);
+export type NatureType = t.TypeOf<typeof NatureType>;
 
 export const Nature = t.union(
   [HomeN, SearchN, VideoN, ChannelN, HashtagN],


### PR DESCRIPTION
This PR improved the `GET /api/v2/metadata` api, by always require the `publicKey` query param and accept the `nature` one to filter results.

Taboule can then benefit from this API for showing data for `home`, `search`, `video` and `profile` nature