### PR TITLE
chore(workspace): defined 'cloc' script to track ts refactor progress

### DIFF
--- a/scripts/cloc.sh
+++ b/scripts/cloc.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Shared
+export shared=./packages/shared
+echo $shared
+cloc $shared --exclude-dir node_modules
+
+# Taboule
+export taboule=./packages/taboule
+echo $taboule
+cloc $taboule --exclude-dir node_modules
+
+# TK TrEx Shared
+export tktrex_shared=./platforms/tktrex/shared
+echo $tktrex_shared
+cloc $tktrex_shared --exclude-dir node_modules
+
+# TK TrEx Ext
+export tktrex_ext=./platforms/tktrex/extension
+echo $tktrex_ext
+cloc $tktrex_ext --exclude-dir node_modules
+
+# TK TrEx Backend
+export tktrex_backend=./platforms/tktrex/backend
+echo $tktrex_backend
+cloc $tktrex_backend --exclude-dir node_modules
+
+# YT TrEx Shared
+export yttrex_shared=./platforms/yttrex/shared/src
+echo $yttrex_shared
+cloc $yttrex_shared --exclude-dir node_modules
+
+# YT TrEx Ext
+export yttrex_ext=./platforms/yttrex/extension
+echo $yttrex_ext
+cloc $yttrex_ext --exclude-dir node_modules
+
+# YT TrEx Backend
+export yttrex_backend=./platforms/yttrex/backend
+echo $yttrex_backend
+cloc $yttrex_backend --exclude-dir node_modules


### PR DESCRIPTION
The script in `scripts/cloc.sh` outputs a table with lines-of-code-per-language, i.e.:

```
./platforms/yttrex/backend
    1370 text files.
     801 unique files.                                          
     615 files ignored.

github.com/AlDanial/cloc v 1.90  T=1.27 s (625.2 files/s, 210716.3 lines/s)
-------------------------------------------------------------------------------
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
JSON                           155              2              0         122863
JavaScript                      55            890            690         109201
HTML                           534           5169              0          24932
TypeScript                      51            590            356           3861
Markdown                         1             14              0             30
Bourne Shell                     1              4              0             20
-------------------------------------------------------------------------------
SUM:                           797           6669           1046         260907
-------------------------------------------------------------------------------

```

This is useful to see the progression of the TS rewrite. 