### PR TITLE
chore(workspace): use debug colors in pm2 logs

### DIFF
--- a/platforms/tktrex/backend/ecosystem.config.js
+++ b/platforms/tktrex/backend/ecosystem.config.js
@@ -1,3 +1,7 @@
+const commonENV = {
+  DEBUG_COLORS: true,
+};
+
 const tk = {
   backend: {
     name: 'server',
@@ -6,6 +10,7 @@ const tk = {
     script: 'yarn start',
     watch: true,
     env: {
+      ...commonENV,
       ...process.env,
       key: process.env.KEY,
     },
@@ -16,10 +21,14 @@ const tk = {
     cwd: __dirname,
     script: 'yarn parserv',
     watch: true,
+    env: {
+      ...commonENV,
+    },
   },
 };
 
 module.exports = {
+  commonENV,
   tk,
   apps: [
     // tk ecosystem

--- a/platforms/tktrex/backend/ecosystem.dev.config.js
+++ b/platforms/tktrex/backend/ecosystem.dev.config.js
@@ -1,4 +1,11 @@
+const { commonENV } = require('./ecosystem.config');
+
+const env = {
+  ...commonENV,
+};
+
 const testEnv = {
+  ...commonENV,
   mongoDb: 'tktrex-test',
 };
 
@@ -9,6 +16,7 @@ const tk = {
     cwd: __dirname,
     script: 'yarn watch',
     watch: false,
+    env,
     env_test: testEnv,
   },
   parser: {
@@ -17,9 +25,8 @@ const tk = {
     cwd: __dirname,
     script: 'yarn parserv:watch --minutesago 10',
     watch: false,
-    env_test: {
-      ...testEnv,
-    },
+    env,
+    env_test: testEnv,
   },
 };
 

--- a/platforms/yttrex/backend/ecosystem.config.js
+++ b/platforms/yttrex/backend/ecosystem.config.js
@@ -1,3 +1,7 @@
+const commonENV = {
+  DEBUG_COLORS: true,
+};
+
 const yt = {
   backend: {
     name: 'yt:server',
@@ -6,6 +10,7 @@ const yt = {
     script: 'yarn start',
     watch: true,
     env: {
+      ...commonENV,
       ...process.env,
       key: process.env.KEY,
     },
@@ -16,6 +21,9 @@ const yt = {
     cwd: __dirname,
     script: 'yarn leaveserv',
     watch: true,
+    env: {
+      ...commonENV,
+    },
   },
   parser: {
     name: 'yt:parserv',
@@ -23,10 +31,14 @@ const yt = {
     cwd: __dirname,
     script: 'yarn parserv',
     watch: true,
+    env: {
+      ...commonENV,
+    },
   },
 };
 
 module.exports = {
+  commonENV,
   yt,
   apps: [
     // yt ecosystem

--- a/platforms/yttrex/backend/ecosystem.dev.config.js
+++ b/platforms/yttrex/backend/ecosystem.dev.config.js
@@ -1,4 +1,11 @@
+const { commonENV } = require('./ecosystem.config');
+
+const env = {
+  ...commonENV,
+};
+
 const testEnv = {
+  ...commonENV,
   mongoDb: 'yttrex-test',
 };
 
@@ -9,6 +16,7 @@ const yt = {
     cwd: __dirname,
     script: 'yarn watch',
     watch: false,
+    env,
     env_test: testEnv,
   },
   leavesParserWatch: {
@@ -17,6 +25,7 @@ const yt = {
     cwd: __dirname,
     script: 'yarn leaveserv:watch',
     watch: false,
+    env,
     env_test: testEnv,
   },
   parserWatch: {
@@ -25,6 +34,7 @@ const yt = {
     cwd: __dirname,
     script: 'yarn parserv:watch --minutesago 60',
     watch: false,
+    env,
     env_test: testEnv,
   },
 };


### PR DESCRIPTION
Enable [debug](https://github.com/debug-js/debug#environment-variables) colors for `pm2 logs`

![Screenshot from 2022-10-06 19-41-55](https://user-images.githubusercontent.com/1838567/194382269-76d95de6-11fd-4f37-b133-ae637ee84bd8.png)
