### PR TITLE
fix(guardoni): expect '–' char as valid delimiter for `onCompleted` column

### DIFF
--- a/.github/workflows/guardoni_pull_request.yml
+++ b/.github/workflows/guardoni_pull_request.yml
@@ -55,8 +55,8 @@ jobs:
       - name: Build shared
         run: yarn shared build
 
-      - name: Build guardoni
-        run: yarn guardoni tsc -b
+      - name: Build guardoni TS
+        run: yarn guardoni build:ts
 
       - name: Start PM2
         run: |

--- a/packages/shared/src/providers/puppeteer/steps/click.ts
+++ b/packages/shared/src/providers/puppeteer/steps/click.ts
@@ -15,6 +15,9 @@ export const CLICK_COMMAND_REGEXP =
   // eslint-disable-next-line no-useless-escape
   /click\(([#|\.]?[\w|:|\s|\.|\-]+);(\d+)\)/;
 
+export const toClickCommand = (selector: string, delay?: number): string =>
+  `click(${selector};${delay ?? 0})`;
+  
 export const parseClickCommand = (
   cmd: string
 ): E.Either<AppError, { selector: string; delay: number }> => {

--- a/packages/shared/src/providers/puppeteer/steps/keyPress.ts
+++ b/packages/shared/src/providers/puppeteer/steps/keyPress.ts
@@ -11,6 +11,12 @@ import { StepContext } from './types';
 
 export const KEYPRESS_COMMAND_REGEXP = /keypress\((\w+);(\d+);(\d+)\)/;
 
+export const toKeypressCommand = (
+  key: string,
+  count: number,
+  interval: number
+): string => `keypress(${key};${count};${interval})`;
+
 export const parseKeypressCommand = (
   cmd: string
 ): E.Either<AppError, { key: puppeteer.KeyInput; times: number }> => {

--- a/packages/shared/src/utils/csv.utils.ts
+++ b/packages/shared/src/utils/csv.utils.ts
@@ -3,10 +3,10 @@ import csvParse from 'csv-parse';
 import * as csvStringify from 'csv-stringify';
 import * as TE from 'fp-ts/lib/TaskEither';
 import { GetLogger } from '../logger';
-const csvLogger = GetLogger('csv')
+const csvLogger = GetLogger('csv');
 
 export const csvParseTE = (
-  content: Buffer,
+  content: string,
   options: csvParse.Options
 ): TE.TaskEither<
   AppError,

--- a/packages/shared/src/utils/task.utils.ts
+++ b/packages/shared/src/utils/task.utils.ts
@@ -1,5 +1,11 @@
 import * as TE from 'fp-ts/lib/TaskEither';
 
+/**
+ * Run a TaskEither, throwing the `left` when present
+ *
+ * @param te
+ * @returns Promise
+ */
 export const throwTE = async <E, A>(te: TE.TaskEither<E, A>): Promise<A> => {
   return await te().then((rr) => {
     if (rr._tag === 'Left') {

--- a/platforms/guardoni/__tests__/cli/cli-tk.spec.ts
+++ b/platforms/guardoni/__tests__/cli/cli-tk.spec.ts
@@ -15,13 +15,8 @@ import axiosMock from '@shared/test/__mocks__/axios.mock';
 import { puppeteerMock } from '@shared/test/__mocks__/puppeteer.mock';
 import { formatExperimentList } from '../../src/guardoni/experiment';
 import { LATEST_RELEASE_URL } from '../../src/guardoni/update-notifier';
-
-const basePath = path.resolve(__dirname, '../../');
-const profileName = 'profile-tk-test-99';
-const ytExtensionDir = path.resolve(basePath, '../yttrex/extension/build');
-const tkExtensionDir = path.resolve(basePath, '../tktrex/extension/build');
-const publicKey = process.env.PUBLIC_KEY;
-const secretKey = process.env.SECRET_KEY;
+import { TestCSV, writeExperimentCSV } from '../../test/writeExperimentCSV';
+import { GetTests, Tests } from '../../test';
 
 axiosMock.get.mockImplementationOnce(() =>
   Promise.resolve({
@@ -40,92 +35,77 @@ describe('CLI', () => {
   const researchTag = 'test-tag';
   let experimentId: string;
   let guardoni: GuardoniCLI;
+  let tests: Tests;
+  let csv: TestCSV;
+  let searchCSV: TestCSV;
 
   jest.setTimeout(60 * 1000);
 
   beforeAll(async () => {
-    fs.mkdirSync(path.resolve(basePath, 'experiments'), {
-      recursive: true,
-    });
+    tests = GetTests('tk-test');
 
-    fs.statSync(ytExtensionDir, { throwIfNoEntry: true });
-    fs.statSync(tkExtensionDir, { throwIfNoEntry: true });
-
-    const comparisonCSVContent = await csvStringifyTE(
-      tests.fc.sample(CommonStepArb, 5),
-      { header: true, encoding: 'utf-8' }
-    )();
-
-    if (comparisonCSVContent._tag === 'Left') {
-      throw comparisonCSVContent.left as any;
-    }
-
-    fs.writeFileSync(
-      path.resolve(basePath, 'experiments/tk-experiment.csv'),
-      comparisonCSVContent.right,
-      'utf-8'
+    csv = await writeExperimentCSV(
+      tests.basePath,
+      tests.fc.sample(CommonStepArb, 5).map((s) => ({
+        ...s,
+        loadFor: undefined,
+        onCompleted: undefined,
+        type: 'openURL',
+      })),
+      'tk-experiment.csv'
     );
 
-    const searchCSVContent = await csvStringifyTE(
-      tests.fc.sample(CommonStepArb, 10),
-      { header: true, encoding: 'utf-8' }
-    )();
+    searchCSV = await writeExperimentCSV(
+      tests.basePath,
+      tests.fc.sample(CommonStepArb, 10).map((s) => ({
+        ...s,
+        loadFor: undefined,
+        onCompleted: undefined,
+        type: 'openURL',
+      })),
+      'tk-search-experiment.csv'
+    );
 
-    if (searchCSVContent._tag === 'Left') {
-      throw searchCSVContent.left as any;
-    }
-
-    fs.writeFileSync(
-      path.resolve(basePath, 'experiments/tk-experiment.csv'),
-      searchCSVContent.right,
-      'utf-8'
+    guardoni = GetGuardoniCLI(
+      {
+        chromePath: '/usr/bin/chrome',
+        basePath: tests.basePath,
+        headless: false,
+        verbose: false,
+        profileName: tests.profileName,
+        tosAccepted: undefined,
+        publicKey: tests.publicKey,
+        secretKey: tests.secretKey,
+        yt: {
+          name: 'youtube',
+          backend: process.env.YT_BACKEND as string,
+          frontend: undefined,
+          extensionDir: tests.ytExtensionDir,
+          proxy: undefined,
+        },
+        tk: {
+          name: 'tiktok',
+          backend: process.env.TK_BACKEND as string,
+          frontend: undefined,
+          extensionDir: tests.tkExtensionDir,
+          proxy: undefined,
+        },
+        loadFor: 3000,
+        researchTag,
+        advScreenshotDir: undefined,
+        excludeURLTag: undefined,
+      },
+      tests.basePath,
+      puppeteerMock,
+      'tiktok'
     );
   });
 
   afterAll(() => {
-    const profileDir = path.resolve(basePath, 'profiles', profileName);
-    if (fs.existsSync(profileDir)) {
-      fs.rmSync(profileDir, {
-        recursive: true,
-      });
-    }
-
-    fs.rmSync(path.resolve(basePath, 'experiments/tk-experiment.csv'));
+    tests.afterAll();
+    csv.remove();
+    searchCSV.remove();
   });
-
-  guardoni = GetGuardoniCLI(
-    {
-      chromePath: '/usr/bin/chrome',
-      basePath: './',
-      headless: false,
-      verbose: false,
-      profileName: profileName,
-      tosAccepted: undefined,
-      publicKey: undefined,
-      secretKey: undefined,
-      yt: {
-        name: 'youtube',
-        backend: process.env.YT_BACKEND as string,
-        frontend: undefined,
-        extensionDir: ytExtensionDir,
-        proxy: undefined,
-      },
-      tk: {
-        name: 'tiktok',
-        backend: process.env.TK_BACKEND as string,
-        frontend: undefined,
-        extensionDir: tkExtensionDir,
-        proxy: undefined,
-      },
-      loadFor: 3000,
-      researchTag,
-      advScreenshotDir: undefined,
-      excludeURLTag: undefined,
-    },
-    basePath,
-    puppeteerMock,
-    'tiktok'
-  );
 
   describe('Register an experiment from a CSV', () => {
     test('fails when the file path is wrong', async () => {
@@ -139,7 +119,7 @@ describe('CLI', () => {
       ).resolves.toMatchObject({
         _tag: 'Left',
         left: {
-          message: `Failed to read csv file ${basePath}/__tests__/fake-file`,
+          message: `Failed to read csv file ${tests.basePath}/__tests__/fake-file`,
         },
       });
     });
@@ -148,7 +128,10 @@ describe('CLI', () => {
       await expect(
         guardoni.run({
           run: 'register-csv',
-          file: path.resolve(basePath, 'experiments/yt-experiment.csv') as any,
+          file: path.resolve(
+            tests.basePath,
+            'experiments/yt-experiment.csv'
+          ) as any,
         })()
       ).resolves.toMatchObject({
         _tag: 'Left',
@@ -166,7 +149,7 @@ describe('CLI', () => {
 
       const result: any = await guardoni.run({
         run: 'register-csv',
-        file: path.resolve(basePath, 'experiments/tk-experiment.csv') as any,
+        file: csv.output,
       })();
 
       expect(result).toMatchObject({
@@ -188,7 +171,7 @@ describe('CLI', () => {
 
       const result: any = await guardoni.run({
         run: 'register-csv',
-        file: path.resolve(basePath, 'experiments/tk-experiment.csv') as any,
+        file: csv.output,
       })();
 
       expect(result).toMatchObject({
@@ -212,7 +195,7 @@ describe('CLI', () => {
 
       const result: any = await guardoni.run({
         run: 'register-csv',
-        file: path.resolve(basePath, 'experiments/tk-experiment.csv') as any,
+        file: searchCSV.output,
       })();
 
       expect(result).toMatchObject({
@@ -236,7 +219,7 @@ describe('CLI', () => {
 
       const result: any = await guardoni.run({
         run: 'register-csv',
-        file: path.resolve(basePath, 'experiments/tk-experiment.csv') as any,
+        file: searchCSV.output,
       })();
 
       expect(result).toMatchObject({
@@ -332,7 +315,7 @@ describe('CLI', () => {
             {
               experimentId,
               researchTag,
-              profileName,
+              profileName: tests.profileName,
             },
           ],
         },
@@ -356,8 +339,8 @@ describe('CLI', () => {
         run: 'experiment',
         experiment: experimentId as any,
         opts: {
-          publicKey: publicKey as any,
-          secretKey: secretKey as any,
+          publicKey: tests.publicKey,
+          secretKey: tests.secretKey,
         },
       })();
 
@@ -367,7 +350,7 @@ describe('CLI', () => {
           message: 'Experiment completed',
           values: [
             {
-              publicKey,
+              publicKey: tests.publicKey,
             },
           ],
         },

--- a/platforms/guardoni/experiments/tk-on-completed-hooks.csv
+++ b/platforms/guardoni/experiments/tk-on-completed-hooks.csv
@@ -1,0 +1,4 @@
+url,urltag,loadFor,watchFor,type,incrementScrollByPX,totalScroll,onCompleted
+https://www.tiktok.com/@nala_cat/,nala,,,openURL,,,click(video;0) - keypress(ArrowDown;10;30000)
+https://www.tiktok.com/@indooroutdoorkat/,indoor,,,openURL,,,click(video;0) – keypress(ArrowDown;10;30000)
+https://www.tiktok.com/@mimi_starr/,mimi,,,openURL,,,click(video;0)–keypress(ArrowDown;10;30000)

--- a/platforms/guardoni/jest.config.js
+++ b/platforms/guardoni/jest.config.js
@@ -8,8 +8,8 @@ const tsPaths = pathsToModuleNameMapper(tsConfig.compilerOptions.paths, {
 
 const moduleNameMapper = {
   ...tsPaths,
-  'boxen': "<rootDir>/__mocks__/boxen.mock.ts",
-  'chalk': "<rootDir>/__mocks__/chalk.mock.ts"
+  boxen: '<rootDir>/__mocks__/boxen.mock.ts',
+  chalk: '<rootDir>/__mocks__/chalk.mock.ts',
 };
 
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */

--- a/platforms/guardoni/package.json
+++ b/platforms/guardoni/package.json
@@ -8,6 +8,7 @@
     "lint": "eslint ./src",
     "format": "prettier -w ./src",
     "test": "jest",
+    "build:ts": "tsc -b",
     "build:cli": "webpack -c webpack.cli.config.ts",
     "build:app": "webpack -c webpack.app.config.ts",
     "watch:cli": "NODE_ENV=development webpack watch -c webpack.cli.config.ts",

--- a/platforms/guardoni/src/electron/events/renderer.events.ts
+++ b/platforms/guardoni/src/electron/events/renderer.events.ts
@@ -16,7 +16,7 @@ import {
   getPlatformConfig,
   setConfig,
 } from '../../guardoni/config';
-import { readCSVAndParse } from '../../guardoni/experiment';
+import { parseExperimentCSV, readCSV } from '../../guardoni/experiment';
 import { GetGuardoni, Guardoni } from '../../guardoni/guardoni';
 import { getExistingProfiles, getProfileDataDir } from '../../guardoni/profile';
 import { GuardoniConfig, Platform, PlatformConfig } from '../../guardoni/types';
@@ -54,10 +54,11 @@ const pickCSVFile = (
     ),
     TE.chain((value) => {
       return pipe(
-        readCSVAndParse(logger)(value.filePaths[0]),
+        readCSV(logger)(value.filePaths[0]),
+        TE.chain(parseExperimentCSV(logger)),
         TE.map((parsed) => ({
           path: value.filePaths[0],
-          parsed: parsed as any,
+          parsed,
         }))
       );
     })

--- a/platforms/guardoni/src/guardoni/__tests__/experiment.spec.ts
+++ b/platforms/guardoni/src/guardoni/__tests__/experiment.spec.ts
@@ -1,0 +1,125 @@
+import { parseExperimentCSV } from '../experiment';
+import { CommonStepArb } from '@shared/arbitraries/Step.arb';
+import { throwTE } from '@shared/utils/task.utils';
+import { GetTests, Tests } from '../../../test/index';
+import { csvStringifyTE } from '@shared/utils/csv.utils';
+import { pipe } from 'fp-ts/lib/function';
+import { toKeypressCommand } from '@shared/providers/puppeteer/steps/keyPress';
+import { toClickCommand } from '@shared/providers/puppeteer/steps/click';
+
+describe('experiment.ts', () => {
+  let tests: Tests;
+
+  beforeAll(async () => {
+    tests = GetTests();
+  });
+
+  describe('parseExperimentCSV', () => {
+    test('succeeds with "-" delimiter for "onCompleted" column', async () => {
+      const keypressCommand = toKeypressCommand('ArrowDown', 5, 1000);
+      const clickCommand = toClickCommand('video');
+
+      const steps = tests.fc.sample(CommonStepArb, 2).map((s, i) => ({
+        ...s,
+        onCompleted:
+          i % 2 == 0
+            ? `${keypressCommand} - ${clickCommand}`
+            : `${keypressCommand}-${clickCommand}`,
+      }));
+
+      const experimentCSVContent = await throwTE(
+        csvStringifyTE(steps, {
+          header: true,
+          encoding: 'utf-8',
+        })
+      );
+
+      const result = await pipe(
+        parseExperimentCSV(tests.logger)(experimentCSVContent),
+        throwTE
+      );
+
+      expect(result).toMatchObject([
+        {
+          type: 'openURL',
+        },
+        {
+          type: 'keypress',
+          key: 'ArrowDown',
+          times: 5,
+          delay: 1000,
+        },
+        {
+          type: 'click',
+          selector: 'video',
+        },
+        {
+          type: 'openURL',
+        },
+        {
+          type: 'keypress',
+          key: 'ArrowDown',
+          times: 5,
+          delay: 1000,
+        },
+        {
+          type: 'click',
+          selector: 'video',
+          delay: 0,
+        },
+      ]);
+    });
+
+    test('succeeds with "–" delimiter for "onCompleted" column', async () => {
+      const keypressCommand = toKeypressCommand('ArrowDown', 5, 1000);
+      const clickCommand = toClickCommand('video');
+
+      const steps = tests.fc.sample(CommonStepArb, 2).map((s) => ({
+        ...s,
+        onCompleted: `${keypressCommand} – ${clickCommand}`,
+      }));
+
+      const experimentCSVContent = await throwTE(
+        csvStringifyTE(steps, {
+          header: true,
+          encoding: 'utf-8',
+        })
+      );
+
+      const result = await pipe(
+        parseExperimentCSV(tests.logger)(experimentCSVContent),
+        throwTE
+      );
+
+      expect(result).toMatchObject([
+        {
+          type: 'openURL',
+        },
+        {
+          type: 'keypress',
+          key: 'ArrowDown',
+          times: 5,
+          delay: 1000,
+        },
+        {
+          type: 'click',
+          selector: 'video',
+        },
+        {
+          type: 'openURL',
+        },
+        {
+          type: 'keypress',
+          key: 'ArrowDown',
+          times: 5,
+          delay: 1000,
+        },
+        {
+          type: 'click',
+          selector: 'video',
+          delay: 0,
+        },
+      ]);
+    });
+  });
+});

--- a/platforms/guardoni/src/guardoni/experiment.ts
+++ b/platforms/guardoni/src/guardoni/experiment.ts
@@ -32,6 +32,7 @@ import {
   GuardoniSuccessOutput,
 } from './types';
 import { liftFromIOE } from './utils';
+import { nonEmptyArray } from 'io-ts-types/lib/nonEmptyArray';
 
 export const validateNonEmptyString = (
   s: string
@@ -41,9 +42,136 @@ export const validateNonEmptyString = (
     E.mapLeft((e) => toValidationError('Empty experiment id', failure(e)))
   );
 
-export const readCSVAndParse =
+const validHookDelimiters = ['–', '-'];
+
+export const parseExperimentCSV =
   (logger: GuardoniContext['logger']) =>
-  (filePath: string): TE.TaskEither<AppError, NonEmptyArray<Step>> => {
+  (body: string): TE.TaskEither<AppError, NonEmptyArray<Step>> => {
+    return pipe(
+      csvParseTE(body, { columns: true, skip_empty_lines: true }),
+      TE.chain(({ records, info }) => {
+        logger.debug('Entries %O', records);
+        return TE.right({ records, info });
+      }),
+      TE.chain(({ records }) =>
+        pipe(
+          nonEmptyArray(t.any).decode(records),
+          E.mapLeft((e) => {
+            return new AppError(
+              'CSV Validation Error',
+              "Can't create an experiment with no links",
+              PathReporter.report(E.left(e))
+            );
+          }),
+          TE.fromEither
+        )
+      ),
+      TE.chain((entries) =>
+        pipe(
+          entries.reduce((acc: any[], { onCompleted, ...r }: any) => {
+            const queue = [];
+            if (r.incrementScrollByPX && r.totalScroll) {
+              const { incrementScrollByPX, totalScroll, interval } = r;
+              const scrollStep = {
+                type: ScrollStepType.value,
+                incrementScrollByPX: +incrementScrollByPX,
+                totalScroll: +totalScroll,
+                interval: interval ? +r.interval : undefined,
+              };
+
+              queue.push(scrollStep);
+            }
+
+            if (typeof onCompleted === 'string') {
+              if (validHookDelimiters.some((d) => onCompleted.includes(d))) {
+                const commands = onCompleted
+                  .split(/-|–/)
+                  .map((c) => c.trim());
+
+                logger.debug('Parsing commands %O', commands);
+
+                const onCompletedSteps = commands.reduce(
+                  (acc: any[], c: string) => {
+                    logger.debug('Parsing command "%s"', c);
+                    if (c.startsWith('keypress')) {
+                      pipe(
+                        parseKeypressCommand(c.trim()),
+                        E.fold(
+                          (e) => {
+                            logger.warn(e.name, e.message);
+                          },
+                          (opts) => {
+                            logger.debug(
+                              'Keypress command %s parsed %O',
+                              c,
+                              opts
+                            );
+                            const keypressStep = {
+                              type: KeyPressType.value,
+                              ...opts,
+                            };
+                            acc.push(keypressStep);
+                          }
+                        )
+                      );
+                    }
+                    if (c.startsWith('click')) {
+                      pipe(
+                        parseClickCommand(c.trim()),
+                        E.fold(
+                          (e) => {
+                            logger.warn(e.name, e.message);
+                          },
+                          (opts) => {
+                            logger.debug('Click command %s parsed %O', c, opts);
+                            const clickStep = {
+                              type: ClickType.value,
+                              ...opts,
+                            };
+                            acc.push(clickStep);
+                          }
+                        )
+                      );
+                    }
+                    return acc;
+                  },
+                  []
+                );
+
+                queue.push(...onCompletedSteps);
+              }
+            }
+
+            return acc
+              .concat({
+                ...r,
+                loadFor: r.loadFor === '' ? undefined : r.loadFor,
+                watchFor: r.watchFor === '' ? undefined : r.watchFor,
+                type: OpenURLStepType.value,
+              })
+              .concat(queue);
+          }, []),
+          nonEmptyArray(Step).decode,
+          E.mapLeft((e) => {
+            return new AppError(
+              'CSVParseError',
+              `The given CSV is not compatible with directive the expected format`,
+              [
+                ...PathReporter.report(E.left(e)),
+                '\n',
+                'You can find examples on https://docs.tracking.exposed/guardoni/guardoni-intro',
+              ]
+            );
+          }),
+          TE.fromEither
+        )
+      )
+    );
+  };
+
+export const readCSV =
+  (logger: GuardoniContext['logger']) =>
+  (filePath: string): TE.TaskEither<AppError, string> => {
     logger.debug('Registering CSV from path %s', filePath);
 
     return pipe(
@@ -55,148 +183,13 @@ export const readCSVAndParse =
         });
       }),
       TE.chain(() => liftFromIOE(() => fs.readFileSync(filePath))),
+      TE.map((b) => b.toString('utf-8')),
       TE.mapLeft((e) => {
         return toAppError({
           ...e,
           message: `Failed to read csv file ${filePath}`,
         });
-      }),
-      TE.chain((input) =>
-        pipe(
-          csvParseTE(input, { columns: true, skip_empty_lines: true }),
-          TE.chain(({ records, info }) => {
-            logger.debug(
-              'Read input from file %s (%d bytes) %d records as %s',
-              filePath,
-              input.length,
-              records.length
-            );
-
-            if (records.length === 0) {
-              return TE.left(
-                toAppError({
-                  message: "Can't create an experiment with no links",
-                })
-              );
-            }
-
-            return TE.right({ records, info });
-          }),
-          TE.chain(({ records }) =>
-            pipe(
-              records.reduce((acc: any[], { onCompleted, ...r }: any) => {
-                const queue = [];
-                if (r.incrementScrollByPX && r.totalScroll) {
-                  const { incrementScrollByPX, totalScroll, interval } = r;
-                  const scrollStep = {
-                    type: ScrollStepType.value,
-                    incrementScrollByPX: +incrementScrollByPX,
-                    totalScroll: +totalScroll,
-                    interval: interval ? +r.interval : undefined,
-                  };
-
-                  queue.push(scrollStep);
-                }
-
-                if (onCompleted) {
-                  if (
-                    onCompleted.indexOf(' - ') ||
-                    onCompleted.indexOf(' – ')
-                  ) {
-                    const commands = onCompleted.indexOf(' - ')
-                      ? onCompleted.split(' - ')
-                      : onCompleted.split(' – ');
-                    logger.debug('Parsing commands %O', commands);
-                    const onCompletedSteps = commands.reduce(
-                      (acc: any[], c: string) => {
-                        logger.debug('Parsing command "%s"', c);
-                        if (c.startsWith('keypress')) {
-                          pipe(
-                            parseKeypressCommand(c.trim()),
-                            E.fold(
-                              (e) => {
-                                logger.warn(e.name, e.message);
-                              },
-                              (opts) => {
-                                logger.debug(
-                                  'Keypress command %s parsed %O',
-                                  c,
-                                  opts
-                                );
-                                const keypressStep = {
-                                  type: KeyPressType.value,
-                                  ...opts,
-                                };
-                                acc.push(keypressStep);
-                              }
-                            )
-                          );
-                        }
-                        if (c.startsWith('click')) {
-                          pipe(
-                            parseClickCommand(c.trim()),
-                            E.fold(
-                              (e) => {
-                                logger.warn(e.name, e.message);
-                              },
-                              (opts) => {
-                                logger.debug(
-                                  'Click command %s parsed %O',
-                                  c,
-                                  opts
-                                );
-                                const clickStep = {
-                                  type: ClickType.value,
-                                  ...opts,
-                                };
-                                acc.push(clickStep);
-                              }
-                            )
-                          );
-                        }
-                        return acc;
-                      },
-                      []
-                    );
-
-                    queue.push(...onCompletedSteps);
-                  }
-                }
-
-                return acc
-                  .concat({
-                    ...r,
-                    loadFor: r.loadFor === '' ? undefined : r.loadFor,
-                    watchFor: r.watchFor === '' ? undefined : r.watchFor,
-                    type: OpenURLStepType.value,
-                  })
-                  .concat(queue);
-              }, [] as any[]),
-              (ss) => {
-                logger.debug('Steps %O', ss);
-                return ss;
-              },
-              t.array(Step).decode,
-              TE.fromEither,
-              TE.mapLeft((e) => {
-                return new AppError(
-                  'CSVParseError',
-                  `The given CSV is not compatible with directive the expected format`,
-                  [
-                    ...PathReporter.report(E.left(e)),
-                    '\n',
-                    'You can find examples on https://docs.tracking.exposed/guardoni/guardoni-intro',
-                  ]
-                );
-              })
-            )
-          ),
-          TE.map((records) => {
-            logger.debug('CSV decoded content %O', records);
-            return records as NonEmptyArray<Step>;
-          })
-        )
-      )
+      })
     );
   };
 
@@ -211,7 +204,8 @@ export const registerCSV =
     ctx.logger.debug(`Register CSV from %s`, filePath);
 
     return pipe(
-      readCSVAndParse(ctx.logger)(filePath),
+      readCSV(ctx.logger)(filePath),
+      TE.chain(parseExperimentCSV(ctx.logger)),
       TE.chain(registerExperiment(ctx))
     );
   };

--- a/platforms/guardoni/test/index.ts
+++ b/platforms/guardoni/test/index.ts
@@ -1,0 +1,59 @@
+import { Logger, trexLogger } from '@shared/logger';
+import * as tests from '@shared/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { getProfileDataDir } from '../src/guardoni/profile';
+import { v4 as uuid } from 'uuid';
+
+export interface Tests {
+  fc: typeof tests.fc;
+  logger: Logger;
+  basePath: string;
+  profileName: string;
+  profileDir: string;
+  ytExtensionDir: string;
+  tkExtensionDir: string;
+  publicKey: string;
+  secretKey: string;
+  afterAll: () => void;
+}
+export const GetTests = (profileName?: string): Tests => {
+  const logger = trexLogger.extend('test');
+
+  const profile = profileName ?? `profile-test-${uuid()}`;
+
+  const basePath = path.resolve(__dirname, '../');
+  const profileDir = getProfileDataDir(basePath, profile);
+  const ytExtensionDir = path.resolve(basePath, '../yttrex/extension/build');
+  const tkExtensionDir = path.resolve(basePath, '../tktrex/extension/build');
+  const publicKey = process.env.PUBLIC_KEY as string;
+  const secretKey = process.env.SECRET_KEY as string;
+
+  fs.mkdirSync(path.resolve(basePath, 'experiments'), {
+    recursive: true,
+  });
+
+  fs.statSync(ytExtensionDir, { throwIfNoEntry: true });
+  fs.statSync(tkExtensionDir, { throwIfNoEntry: true });
+
+  const afterAll = (): void => {
+    if (fs.existsSync(profileDir)) {
+      fs.rmSync(profileDir, {
+        recursive: true,
+      });
+    }
+  };
+
+  return {
+    ...tests,
+    logger,
+    basePath,
+    profileName: profile,
+    profileDir,
+    ytExtensionDir,
+    tkExtensionDir,
+    publicKey,
+    secretKey,
+    afterAll,
+  };
+};

--- a/platforms/guardoni/test/writeExperimentCSV.ts
+++ b/platforms/guardoni/test/writeExperimentCSV.ts
@@ -1,0 +1,39 @@
+import { Step } from '@shared/models/Step';
+import { csvStringifyTE } from '@shared/utils/csv.utils';
+import { throwTE } from '@shared/utils/task.utils';
+import * as path from 'path';
+import * as fs from 'fs';
+import { NonEmptyString } from 'io-ts-types/lib/NonEmptyString';
+
+export interface TestCSV {
+  output: NonEmptyString;
+  remove: () => void;
+}
+
+export const writeExperimentCSV = async (
+  basePath: string,
+  steps: Step[],
+  fileName: string
+): Promise<TestCSV> => {
+  const experimentCSVContent = await throwTE(
+    csvStringifyTE(steps, {
+      header: true,
+      encoding: 'utf-8',
+    })
+  );
+  const output = path.resolve(
+    basePath,
+    'experiments',
+    `${fileName}.csv`
+  ) as NonEmptyString;
+
+  fs.writeFileSync(output, experimentCSVContent, 'utf-8');
+
+  const remove = (): void => {
+    fs.rmSync(output);
+  };
+  return {
+    output,
+    remove,
+  };
+};

--- a/platforms/guardoni/tsconfig.json
+++ b/platforms/guardoni/tsconfig.json
@@ -27,7 +27,7 @@
       "@tktrex/shared/*": ["../../tktrex/shared/src/*"]
     }
   },
-  "include": ["./src", "__mocks__", "__tests__", "./typings"],
+  "include": ["./src", "__mocks__", "__tests__", "./test", "./typings"],
   "exclude": ["node_modules", "build", "dist"],
   "watchOptions": {
     "watchFile": "useFsEvents",

--- a/platforms/tktrex/backend/lib/CSV.ts
+++ b/platforms/tktrex/backend/lib/CSV.ts
@@ -123,7 +123,7 @@ export function flattenProfile(
   // to produce CSV.
 
   _.each(metaprofile.results || [], function (result, order) {
-    /* TODO 
+    /* TODO
     const thumbfile =
       metaprofile.thumbnails && metaprofile.thumbnails.length
         ? metaprofile.thumbnails[order]?.filename


### PR DESCRIPTION
This PR will enable to delimit _hooks_ in experiments with either `-` or `–` and prevent hooks parsing error from happening again.  