### PR TITLE
fix(yt:ext): enabled experimentId UI in popup

### DIFF
--- a/platforms/yttrex/extension/src/popup.tsx
+++ b/platforms/yttrex/extension/src/popup.tsx
@@ -15,7 +15,7 @@ renderPopup({
   settings: {
     enabled: {
       researchTag: true,
-      experimentId: config.DEVELOPMENT,
+      experimentId: true,
     },
   },
   getLinks: ({ publicKey }) => {


### PR DESCRIPTION
UI for setting the `experimentId` was enabled only for `NODE_ENV=development` in `yt:ext`