### PR TITLE
feat(tk:backend): validate and save contribution events of type 'api'

### DIFF
--- a/packages/shared/src/utils/fp.utils.ts
+++ b/packages/shared/src/utils/fp.utils.ts
@@ -1,6 +1,9 @@
 import { pipe } from 'fp-ts/lib/function';
 import * as TE from 'fp-ts/lib/TaskEither';
 import * as E from 'fp-ts/lib/Either';
+import * as t from 'io-ts';
+import * as A from 'fp-ts/lib/Array';
+import * as O from 'fp-ts/lib/Option';
 
 /**
  * An utility method to transform TaskEither to Promise
@@ -13,7 +16,7 @@ export const foldTEOrThrow = <E, A>(te: TE.TaskEither<E, A>): Promise<A> => {
       (e) => () => {
         // eslint-disable-next-line
         console.error(e);
-       return Promise.reject(e)
+        return Promise.reject(e);
       },
       (a) => () => Promise.resolve(a)
     )
@@ -37,5 +40,28 @@ export const throwEitherError = <E, A>(e: E.Either<E, A>): A => {
       },
       (a) => a
     )
+  );
+};
+
+/**
+ * Filter an array by the given codec and return only valid elements
+ *
+ * @param arr
+ * @param decode
+ * @returns
+ */
+export const filterByCodec = <T, A>(arr: T[], decode: t.Decode<T, A>): A[] => {
+  return pipe(
+    arr,
+    A.map((a) =>
+      pipe(
+        decode(a),
+        E.fold(
+          (e) => O.none,
+          (v) => O.some(v)
+        )
+      )
+    ),
+    A.compact
   );
 };

--- a/platforms/tktrex/backend/config/settings.json
+++ b/platforms/tktrex/backend/config/settings.json
@@ -6,7 +6,8 @@
     "metadata": "metadata",
     "full": "full",
     "emails": "emails2",
-    "experiments": "experiments2"
+    "experiments": "experiments2",
+    "apiRequests": "apiRequests"
   },
 
   "mongoHost": "localhost",

--- a/platforms/tktrex/backend/models/APIRequest.ts
+++ b/platforms/tktrex/backend/models/APIRequest.ts
@@ -1,0 +1,15 @@
+import { APIRequestContributionEvent } from '@tktrex/shared/models/apiRequest/APIRequestContributionEvent';
+import * as t from 'io-ts';
+import { date } from 'io-ts-types/lib/date';
+
+export const APIRequestEventDB = t.type(
+  {
+    ...APIRequestContributionEvent.type.props,
+    _id: t.string,
+    id: t.string,
+    savingTime: date,
+    publicKey: t.string,
+  },
+  'APIRequestEventDB'
+);
+export type APIRequestEventDB = t.TypeOf<typeof APIRequestEventDB>;

--- a/platforms/tktrex/backend/routes/__tests__/events.e2e.ts
+++ b/platforms/tktrex/backend/routes/__tests__/events.e2e.ts
@@ -5,7 +5,7 @@ import { ContributionEventArb } from '@tktrex/shared/arbitraries/ContributionEve
 import { GetTest, Test } from '../../test/Test';
 
 const version = '9.9.9.9';
-describe('Events', () => {
+describe('Events Route', () => {
   let appTest: Test;
 
   beforeAll(async () => {
@@ -32,6 +32,7 @@ describe('Events', () => {
       // check events
       const response = await appTest.app
         .post(`/api/v2/events`)
+        .set('x-tktrex-build', new Date().toISOString())
         .set('x-tktrex-version', version)
         .set('X-tktrex-publicKey', keys.publicKey)
         .set('x-tktrex-signature', signature)

--- a/platforms/tktrex/backend/routes/__tests__/personal.e2e.ts
+++ b/platforms/tktrex/backend/routes/__tests__/personal.e2e.ts
@@ -128,6 +128,7 @@ describe('/v2/personal', () => {
       // send events
       await appTest.app
         .post(`/api/v2/events`)
+        .set('x-tktrex-build', new Date().toISOString())
         .set('x-tktrex-version', version)
         .set('X-tktrex-publicKey', keys.publicKey)
         .set('x-tktrex-signature', signature)
@@ -228,6 +229,7 @@ describe('/v2/personal', () => {
       // send events
       await appTest.app
         .post(`/api/v2/events`)
+        .set('x-tktrex-build', new Date().toISOString())
         .set('x-tktrex-version', version)
         .set('X-tktrex-publicKey', keys.publicKey)
         .set('x-tktrex-signature', signature)

--- a/platforms/tktrex/backend/scripts/build-indexes.js
+++ b/platforms/tktrex/backend/scripts/build-indexes.js
@@ -38,3 +38,10 @@ ret = db.htmls.createIndex({ metadataId: -1 });
 checkret('htmls metadataId', ret);
 ret = db.htmls.createIndex({ processed: 1 });
 checkret('htmls processed', ret);
+
+ret = db.apiRequests.createIndex({ id: 1 }, { unique: true });
+checkret('apiRequests.id', ret);
+ret = db.apiRequests.createIndex({ experimentId: 1 });
+checkret('apiRequests.experimentId', ret);
+ret = db.apiRequests.createIndex({ publicKey: 1 });
+checkret('apiRequests.publicKey', ret);

--- a/platforms/tktrex/extension/__tests__/app.spec.ts
+++ b/platforms/tktrex/extension/__tests__/app.spec.ts
@@ -181,9 +181,11 @@ describe('TK App', () => {
         headers: {
           Accept: 'application/json',
           'Content-Type': 'application/json',
+          'Content-Length': expect.any(Number),
           'X-Tktrex-Build': process.env.BUILD_DATE,
           'X-Tktrex-NonAuthCookieId': researchTag,
           'X-Tktrex-PublicKey': process.env.PUBLIC_KEY,
+          'X-Tktrex-Signature': expect.any(String),
           'X-Tktrex-Version': process.env.VERSION,
         },
       });
@@ -268,9 +270,11 @@ describe('TK App', () => {
         headers: {
           Accept: 'application/json',
           'Content-Type': 'application/json',
+          'Content-Length': expect.any(Number),
           'X-Tktrex-Build': process.env.BUILD_DATE,
           'X-Tktrex-NonAuthCookieId': researchTag,
           'X-Tktrex-PublicKey': process.env.PUBLIC_KEY,
+          'X-Tktrex-Signature': expect.any(String),
           'X-Tktrex-Version': process.env.VERSION,
         },
       });

--- a/platforms/tktrex/extension/__tests__/profile.spec.ts
+++ b/platforms/tktrex/extension/__tests__/profile.spec.ts
@@ -157,6 +157,7 @@ describe('TK App - profile ', () => {
         headers: {
           Accept: 'application/json',
           'Content-Type': 'application/json',
+          'Content-Length': expect.any(Number),
           'X-Tktrex-Build': process.env.BUILD_DATE,
           'X-Tktrex-NonAuthCookieId': researchTag,
           'X-Tktrex-PublicKey': process.env.PUBLIC_KEY,

--- a/platforms/tktrex/extension/src/background/api.ts
+++ b/platforms/tktrex/extension/src/background/api.ts
@@ -27,8 +27,9 @@ export const getHeadersForDataDonation = async(req: SyncReq): Promise<any> => {
 
   tkLog.debug('Signing payload %O', payload);
 
+  const data = JSON.stringify(payload);
   const signatureUint = nacl.sign.detached(
-    decodeString(JSON.stringify(payload)),
+    decodeString(data),
     decodeFromBase58(userSettings.secretKey),
   );
 
@@ -38,6 +39,7 @@ export const getHeadersForDataDonation = async(req: SyncReq): Promise<any> => {
 
   const headers = {
     'Content-Type': 'application/json',
+    'Content-Length': data.length,
     'X-Tktrex-Version': config.VERSION,
     'X-Tktrex-Build': config.BUILD,
     'X-Tktrex-NonAuthCookieId': userSettings.researchTag ?? '',

--- a/platforms/tktrex/shared/src/arbitraries/APIRequestContributionEvent.arb.ts
+++ b/platforms/tktrex/shared/src/arbitraries/APIRequestContributionEvent.arb.ts
@@ -1,0 +1,14 @@
+import { fc } from '@shared/test';
+import { propsOmit } from '@shared/utils/arbitrary.utils';
+import { getArbitrary } from 'fast-check-io-ts';
+import * as t from 'io-ts';
+import { APIRequestContributionEvent } from '../models/apiRequest/APIRequestContributionEvent';
+
+export const APIRequestEventArb: fc.Arbitrary<APIRequestContributionEvent> =
+  getArbitrary(
+    t.type({ ...propsOmit(APIRequestContributionEvent, ['clientTime']) }),
+  ).map((e) => ({
+    ...e,
+    clientTime: new Date(),
+    payload: fc.sample(fc.jsonValue(), 1)[0],
+  }));

--- a/platforms/tktrex/shared/src/arbitraries/ContributionEvent.arb.ts
+++ b/platforms/tktrex/shared/src/arbitraries/ContributionEvent.arb.ts
@@ -1,10 +1,10 @@
-import { getArbitrary } from 'fast-check-io-ts';
-import { ContributionEvent } from '../models/events/ContributionEvent';
 import { propsOmit } from '@shared/utils/arbitrary.utils';
+import { getArbitrary } from 'fast-check-io-ts';
 import * as t from 'io-ts';
+import { HTMLContributionEvent } from '../models/events/ContributionEvent';
 
 export const ContributionEventArb = getArbitrary(
-  t.strict(propsOmit(ContributionEvent, ['clientTime', 'rect'])),
+  t.strict(propsOmit(HTMLContributionEvent, ['clientTime', 'rect'])),
 ).map((e) => ({
   ...e,
   clientTime: new Date().toISOString(),

--- a/platforms/tktrex/shared/src/endpoints/v2/public.endpoints.ts
+++ b/platforms/tktrex/shared/src/endpoints/v2/public.endpoints.ts
@@ -21,7 +21,20 @@ const AddEvents = DocumentedEndpoint({
   getPath: () => '/v2/events',
   Input: {
     Headers: apiModel.http.Headers.TKHeaders,
-    Body: t.array(apiModel.Events.ContributionEvent),
+    Body: t.array(apiModel.Events.HTMLContributionEvent),
+  },
+  Output: t.any,
+  title: 'Add contribution events',
+  description: '',
+  tags: ['events'],
+});
+
+const AddAPIEvents = DocumentedEndpoint({
+  Method: 'POST',
+  getPath: () => '/v2/apiEvents',
+  Input: {
+    Headers: apiModel.http.Headers.TKHeaders,
+    Body: t.array(apiModel.APIRequest.APIRequestContributionEvent),
   },
   Output: t.any,
   title: 'Add contribution events',
@@ -62,6 +75,7 @@ const GetQueryList = DocumentedEndpoint({
 
 export default {
   AddEvents,
+  AddAPIEvents,
   Handshake,
   GetSearches,
   GetSearchByQuery,

--- a/platforms/tktrex/shared/src/helpers/uniqueId.ts
+++ b/platforms/tktrex/shared/src/helpers/uniqueId.ts
@@ -86,3 +86,23 @@ export const getMetadataId = encodeUtils.GetEncodeUtils(
     ...m,
   }),
 );
+
+export const getAPIRequestId = encodeUtils.GetEncodeUtils(
+  ({
+    href,
+    id: timelineId,
+    videoCounter,
+    feedCounter,
+    incremental,
+  }: Omit<GetUniqueIdOpts, 'nature'>) => ({
+    href,
+    /* based on the 'body.type' we might have fields that are updated
+     * (like search, profile, where the user can scroll and report larger evidences)
+     * or video block in 'following' or 'foryou', with a fixed url */
+    nature: { type: 'api' },
+    /* the timeline guarantee uniqueness by user, version, feedId */
+    timelineId,
+    /* the counters guarantee an increment at each evidence sent by extension */
+    counters: `v(${videoCounter})f(${feedCounter})i(${incremental})`,
+  }),
+);

--- a/platforms/tktrex/shared/src/models/apiRequest/APIRequest.ts
+++ b/platforms/tktrex/shared/src/models/apiRequest/APIRequest.ts
@@ -1,0 +1,12 @@
+import * as t from 'io-ts';
+import { APIRequestContributionEvent } from './APIRequestContributionEvent';
+
+export const APIRequest = t.strict(
+  {
+    ...APIRequestContributionEvent.type.props,
+    id: t.string,
+    supporter: t.string,
+  },
+  'APIRequest',
+);
+export type APIRequest = t.TypeOf<typeof APIRequest>;

--- a/platforms/tktrex/shared/src/models/apiRequest/APIRequestContributionEvent.ts
+++ b/platforms/tktrex/shared/src/models/apiRequest/APIRequestContributionEvent.ts
@@ -1,0 +1,21 @@
+import * as t from 'io-ts';
+import { date } from 'io-ts-types/date';
+import { DateFromISOString } from 'io-ts-types/DateFromISOString';
+
+export const APIRequestContributionEvent = t.strict(
+  {
+    type: t.literal('api'),
+    href: t.string,
+    payload: t.unknown,
+    clientTime: t.union([DateFromISOString, date]),
+    incremental: t.number,
+    feedId: t.string,
+    feedCounter: t.number,
+    videoCounter: t.number,
+    experimentId: t.union([t.string, t.undefined]),
+  },
+  'APIRequestContributionEvent',
+);
+export type APIRequestContributionEvent = t.TypeOf<
+  typeof APIRequestContributionEvent
+>;

--- a/platforms/tktrex/shared/src/models/apiRequest/index.ts
+++ b/platforms/tktrex/shared/src/models/apiRequest/index.ts
@@ -1,0 +1,2 @@
+export * from './APIRequest';
+export * from './APIRequestContributionEvent';

--- a/platforms/tktrex/shared/src/models/events/ContributionEvent.ts
+++ b/platforms/tktrex/shared/src/models/events/ContributionEvent.ts
@@ -1,6 +1,6 @@
 import * as t from 'io-ts';
 
-export const ContributionEvent = t.strict(
+export const HTMLContributionEvent = t.strict(
   {
     html: t.string,
     href: t.string,
@@ -17,7 +17,10 @@ export const ContributionEvent = t.strict(
       t.literal('native'),
     ]),
   },
-  'ContributionEvent',
+  'HTMLContributionEvent',
 );
+export type HTMLContributionEvent = t.TypeOf<typeof HTMLContributionEvent>;
 
+// TODO: this is just an old alias, remove it when possible
+export const ContributionEvent = HTMLContributionEvent;
 export type ContributionEvent = t.TypeOf<typeof ContributionEvent>;

--- a/platforms/tktrex/shared/src/models/http/TKHeaders.ts
+++ b/platforms/tktrex/shared/src/models/http/TKHeaders.ts
@@ -1,7 +1,9 @@
 import * as t from 'io-ts';
+import _ from 'lodash';
 
 export const TKHeaders = t.type(
   {
+    'Content-Length': t.any,
     'X-Tktrex-Version': t.string,
     'X-Tktrex-Build': t.string,
     'X-Tktrex-PublicKey': t.string,
@@ -11,3 +13,19 @@ export const TKHeaders = t.type(
 );
 
 export type TKHeaders = t.TypeOf<typeof TKHeaders>;
+
+// when the headers are received on the backend they get lowercased
+// and so we derive a "lower case" (LC) codec from `TKHeaders`
+const tkHeadersLCProps = {
+  ...Object.entries(TKHeaders.props).reduce(
+    (acc, [key, codec]) => ({
+      ...acc,
+      [_.toLower(key)]: codec,
+    }),
+    {},
+  ),
+};
+
+export const TKHeadersLC = t.type(tkHeadersLCProps, 'TKHeadersLC');
+
+export type TKHeadersLC = t.TypeOf<typeof TKHeadersLC>;

--- a/platforms/tktrex/shared/src/models/http/index.ts
+++ b/platforms/tktrex/shared/src/models/http/index.ts
@@ -1,3 +1,5 @@
+import * as APIRequest from './query';
+import * as Search from './Search';
 import { TKHeaders } from './TKHeaders';
 
-export default { Headers: { TKHeaders } };
+export default { Headers: { TKHeaders }, Query: { APIRequest, Search } };

--- a/platforms/tktrex/shared/src/models/http/query/ListAPIRequest.query.ts
+++ b/platforms/tktrex/shared/src/models/http/query/ListAPIRequest.query.ts
@@ -1,0 +1,25 @@
+import * as t from 'io-ts';
+import { APIRequest } from '../../apiRequest/APIRequest';
+import { ListQueryBase } from './ListQueryBase.query';
+
+/**
+ * The codec for the Query used for GET /v2/metadata endpoint
+ */
+export const ListAPIRequestQuery = t.type(
+  {
+    ...ListQueryBase.props,
+    publicKey: t.union([t.string, t.undefined]),
+    experimentId: t.union([t.string, t.undefined]),
+    researchTag: t.union([t.string, t.undefined]),
+    sort: t.union([
+      t.record(t.keyof(APIRequest.type.props), t.number),
+      t.undefined,
+    ]),
+    // we want the filter to be specific for
+    // the nature given
+    // filter: t.union([ListHashtagMetadataQuery, t.undefined]),
+  },
+  'ListMetadataQuery',
+);
+
+export type ListAPIRequestQuery = t.TypeOf<typeof ListAPIRequestQuery>;

--- a/platforms/tktrex/shared/src/models/http/query/ListQueryBase.query.ts
+++ b/platforms/tktrex/shared/src/models/http/query/ListQueryBase.query.ts
@@ -1,0 +1,12 @@
+import * as t from 'io-ts';
+import { NumberFromString } from 'io-ts-types/lib/NumberFromString';
+
+export const ListQueryBase = t.type(
+  {
+    amount: t.union([NumberFromString, t.number, t.undefined]),
+    skip: t.union([NumberFromString, t.number, t.undefined]),
+  },
+  'ListQueryBase',
+);
+
+export type ListQueryBase = t.TypeOf<typeof ListQueryBase>;

--- a/platforms/tktrex/shared/src/models/http/query/index.ts
+++ b/platforms/tktrex/shared/src/models/http/query/index.ts
@@ -1,0 +1,2 @@
+export * from './ListAPIRequest.query';
+export * from './ListQueryBase.query';

--- a/platforms/tktrex/shared/src/models/index.ts
+++ b/platforms/tktrex/shared/src/models/index.ts
@@ -1,8 +1,9 @@
 import http from './http';
 import * as Events from './events/ContributionEvent';
+import * as APIRequest from './apiRequest/index';
 import * as Personal from './personal';
 import * as Public from './public';
 import * as TKMetadata from './metadata';
 import * as Nature from './Nature';
 
-export { Events, Personal, Public, TKMetadata, http, Nature };
+export { Events, APIRequest, Personal, Public, TKMetadata, http, Nature };


### PR DESCRIPTION
I've defined the implementation for `POST /api/v2/apiEvents` and it:
- receives and accepts new event of `type: "api"` - mixed events can be sent but they get discarded at the moment
- validates the `headers`
- saves the event in the `apiRequests` collection

I also defined the _indexes_ for the collection in the proper file.



