### PR TITLE
chore(workspace): pre-push hook

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,23 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+
+yarn build
+docker-compose up -d mongodb
+# start mongo db for tk and clean data from test db
+docker-compose up -d mongo-tk-test-indexes
+yarn tk:backend clean-test-db
+
+# start mongo db for yt and clean data from test db
+docker-compose up -d mongo-yt-test-indexes
+yarn yt:backend clean-test-db
+
+# start backends and parsers with 'test' environment with pm2
+yarn pm2 restart -a --env test platforms/ecosystem.dev.config.js
+yarn pm2 save
+
+# run tests one after the other to be sure the data doesn't overlap and make some of them fail
+yarn test --ci --runInBand --bail --forceExit
+
+# restart backends and parsers with 'development' environment
+yarn pm2 restart -a --env development platforms/ecosystem.dev.config.js

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,8 +1,6 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-
-yarn build
 docker-compose up -d mongodb
 # start mongo db for tk and clean data from test db
 docker-compose up -d mongo-tk-test-indexes
@@ -13,11 +11,11 @@ docker-compose up -d mongo-yt-test-indexes
 yarn yt:backend clean-test-db
 
 # start backends and parsers with 'test' environment with pm2
-yarn pm2 restart -a --env test platforms/ecosystem.dev.config.js
-yarn pm2 save
+# yarn pm2 restart -a --env test platforms/ecosystem.dev.config.js
+# yarn pm2 save
 
 # run tests one after the other to be sure the data doesn't overlap and make some of them fail
-yarn test --ci --runInBand --bail --forceExit
+yarn test --ci --bail --forceExit
 
 # restart backends and parsers with 'development' environment
-yarn pm2 restart -a --env development platforms/ecosystem.dev.config.js
+# yarn pm2 restart -a --env development platforms/ecosystem.dev.config.js

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This monorepo will eventually include all `packages` needed and `platforms` supp
 - `node >=16`
 - `yarn >=3.2.3`
 - [node-canvas](https://github.com/Automattic/node-canvas) deps depending on your OS
+- `docker`
 
 ## Monorepo structure
 
@@ -25,7 +26,6 @@ This monorepo will eventually include all `packages` needed and `platforms` supp
     - [tk:shared](./platforms/tktrex/shared/README.md)
     - [tk:ext](./platforms/tktrex/extension/README.md)
     - [tk:backend](./platforms/tktrex/backend/README.md)
-
 
 ### To start the services in production:
 

--- a/packages/shared/src/backend/scripts/clean-test-db.ts
+++ b/packages/shared/src/backend/scripts/clean-test-db.ts
@@ -1,0 +1,28 @@
+#!/usr/bin/env ts-node
+/* eslint-disable camelcase */
+
+import nconf from 'nconf';
+import { Logger } from '../../logger';
+import * as mongo from '../../providers/mongo.provider';
+
+export const cleanTestDB = async (
+  logger: Logger,
+  testDB: string,
+  collections: string[]
+): Promise<void> => {
+  const log = logger.extend('clean-test-db');
+  // ensure we're deleting data from the test db
+  nconf.set('mongoDb', testDB);
+  const mongoC = await mongo.clientConnect();
+
+  await Promise.all(
+    collections.map(async (c) => {
+      log.debug('Cleaning %s...', c);
+      await mongo.deleteMany(mongoC, c, {
+        id: { $exists: true },
+      });
+    })
+  );
+
+  await mongoC.close();
+};

--- a/platforms/tktrex/backend/package.json
+++ b/platforms/tktrex/backend/package.json
@@ -11,7 +11,8 @@
     "start": "DEBUG=\"*,-body-parser:*,-express:*,-lib:cache,-send\" node build/bin/server",
     "parserv:watch": "DEBUG=\"*\" ts-node-dev -r tsconfig-paths/register bin/parser",
     "parserv": "DEBUG=\"*,-@trex:htmls:debug\" node build/bin/parser",
-    "build": "tsc -b tsconfig.build.json"
+    "build": "tsc -b tsconfig.build.json",
+    "clean-test-db": "DEBUG=\"tk:*\" ts-node ./scripts/clean-test-db.ts"
   },
   "author": "https://github.com/tracking-exposed/tktrex/graphs/contributors",
   "repository": {

--- a/platforms/tktrex/backend/scripts/clean-test-db.ts
+++ b/platforms/tktrex/backend/scripts/clean-test-db.ts
@@ -1,0 +1,58 @@
+#!/usr/bin/env ts-node
+/* eslint-disable camelcase */
+
+import D from 'debug';
+import dotenv from 'dotenv';
+import nconf from 'nconf';
+import * as mongo from '../../../../packages/shared/src/providers/mongo.provider';
+
+dotenv.config({ path: '.env.development' });
+
+const cfgFile = 'config/settings.json';
+
+nconf.argv().env().file({ file: cfgFile });
+
+const logger = D('tk:clean-test-db');
+
+const run = async (): Promise<void> => {
+  // ensure we're deleting data from the test db
+  nconf.set('mongoDb', 'tktrex-test');
+  const mongoC = await mongo.clientConnect();
+
+  logger('Cleaning all metadata...');
+  await mongo.deleteMany(mongoC, nconf.get('schema').metadata, {
+    id: { $exists: true },
+  });
+
+  logger('Cleaning all htmls...');
+  await mongo.deleteMany(mongoC, nconf.get('schema').htmls, {
+    id: { $exists: true },
+  });
+
+  logger('Cleaning all experiments...');
+  await mongo.deleteMany(mongoC, nconf.get('schema').experiments, {
+    id: { $exists: true },
+  });
+
+  logger('Cleaning all supporters...');
+  await mongo.deleteMany(mongoC, nconf.get('schema').supporters, {
+    id: { $exists: true },
+  });
+
+  /**
+   * Upcoming new collections for 2.8
+   */
+  // logger('Cleaning all apiRequests...');
+  // await mongo.deleteMany(mongoC, nconf.get('schema').apiRequests, {
+  //   id: { $exists: true },
+  // });
+
+  // logger('Cleaning all sigiStates...');
+  // await mongo.deleteMany(mongoC, nconf.get('schema').sigiStates, {
+  //   id: { $exists: true },
+  // });
+
+  await mongoC.close();
+};
+
+void run();

--- a/platforms/tktrex/backend/scripts/clean-test-db.ts
+++ b/platforms/tktrex/backend/scripts/clean-test-db.ts
@@ -1,10 +1,9 @@
 #!/usr/bin/env ts-node
-/* eslint-disable camelcase */
 
-import D from 'debug';
 import dotenv from 'dotenv';
 import nconf from 'nconf';
-import * as mongo from '../../../../packages/shared/src/providers/mongo.provider';
+import { cleanTestDB } from '../../../../packages/shared/src/backend/scripts/clean-test-db';
+import { trexLogger } from '../../../../packages/shared/src/logger';
 
 dotenv.config({ path: '.env.development' });
 
@@ -12,47 +11,15 @@ const cfgFile = 'config/settings.json';
 
 nconf.argv().env().file({ file: cfgFile });
 
-const logger = D('tk:clean-test-db');
-
 const run = async (): Promise<void> => {
-  // ensure we're deleting data from the test db
-  nconf.set('mongoDb', 'tktrex-test');
-  const mongoC = await mongo.clientConnect();
-
-  logger('Cleaning all metadata...');
-  await mongo.deleteMany(mongoC, nconf.get('schema').metadata, {
-    id: { $exists: true },
-  });
-
-  logger('Cleaning all htmls...');
-  await mongo.deleteMany(mongoC, nconf.get('schema').htmls, {
-    id: { $exists: true },
-  });
-
-  logger('Cleaning all experiments...');
-  await mongo.deleteMany(mongoC, nconf.get('schema').experiments, {
-    id: { $exists: true },
-  });
-
-  logger('Cleaning all supporters...');
-  await mongo.deleteMany(mongoC, nconf.get('schema').supporters, {
-    id: { $exists: true },
-  });
-
-  /**
-   * Upcoming new collections for 2.8
-   */
-  // logger('Cleaning all apiRequests...');
-  // await mongo.deleteMany(mongoC, nconf.get('schema').apiRequests, {
-  //   id: { $exists: true },
-  // });
-
-  // logger('Cleaning all sigiStates...');
-  // await mongo.deleteMany(mongoC, nconf.get('schema').sigiStates, {
-  //   id: { $exists: true },
-  // });
-
-  await mongoC.close();
+  await cleanTestDB(trexLogger.extend('tk'), 'tktrex-test', [
+    nconf.get('schema').metadata,
+    nconf.get('schema').htmls,
+    nconf.get('schema').experiments,
+    nconf.get('schema').supporters,
+    nconf.get('schema').apiRequests,
+    nconf.get('schema').sigiStates,
+  ]);
 };
 
 void run();

--- a/platforms/yttrex/backend/__tests__/parser/html/parseSearch.e2e.ts
+++ b/platforms/yttrex/backend/__tests__/parser/html/parseSearch.e2e.ts
@@ -139,7 +139,7 @@ describe('Parser: Search', () => {
           });
 
           expect(_receivedResults).toMatchObject(
-            _expectedResults.map(({ secondsAgo, ...r }) => r)
+            _expectedResults.map(({ secondsAgo, published, ...r }) => r)
           );
         },
       })({ sources, metadata });

--- a/platforms/yttrex/backend/package.json
+++ b/platforms/yttrex/backend/package.json
@@ -17,7 +17,8 @@
     "type-check": "tsc",
     "lint": "eslint ./bin ./lib ./models ./routes",
     "open-doc-api": "ts-node bin/open-doc-api.ts",
-    "old_start_old": "log=$(bash -c 'git log -30 --stat --oneline --decorate --graph') DEBUG=\"*,-body-parser:*,-express:*,-lib:*,-follow-redirects\" ts-node -r tsconfig-paths/register bin/server"
+    "old_start_old": "log=$(bash -c 'git log -30 --stat --oneline --decorate --graph') DEBUG=\"*,-body-parser:*,-express:*,-lib:*,-follow-redirects\" ts-node -r tsconfig-paths/register bin/server",
+    "clean-test-db": "DEBUG=\"yt:*\" ts-node ./scripts/clean-test-db.ts"
   },
   "author": "Claudio Agosti <claudio@tracking.exposed> and https://github.com/tracking-exposed/yttrex/graphs/contributors",
   "license": "AGPL-3.0",

--- a/platforms/yttrex/backend/scripts/clean-test-db.ts
+++ b/platforms/yttrex/backend/scripts/clean-test-db.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env ts-node
+/* eslint-disable camelcase */
+
+import D from 'debug';
+import dotenv from 'dotenv';
+import nconf from 'nconf';
+import * as mongo from '../../../../packages/shared/src/providers/mongo.provider';
+
+dotenv.config({ path: '.env.development' });
+
+const cfgFile = 'config/settings.json';
+
+nconf.argv().env().file({ file: cfgFile });
+
+const logger = D('yt:backend:clean-test-db');
+
+const run = async (): Promise<void> => {
+  // ensure we're deleting data from the test db
+  nconf.set('mongoDb', 'yttrex-test');
+
+  const mongoC = await mongo.clientConnect();
+
+  logger('Cleaning all metadata...');
+  await mongo.deleteMany(mongoC, nconf.get('schema').metadata, {
+    id: { $exists: true },
+  });
+
+  logger('Cleaning all ads...');
+  await mongo.deleteMany(mongoC, nconf.get('schema').ads, {
+    id: { $exists: true },
+  });
+
+  logger('Cleaning all htmls...');
+  await mongo.deleteMany(mongoC, nconf.get('schema').htmls, {
+    id: { $exists: true },
+  });
+
+  logger('Cleaning all leaves...');
+  await mongo.deleteMany(mongoC, nconf.get('schema').leaves, {
+    id: { $exists: true },
+  });
+
+  logger('Cleaning all experiments...');
+  await mongo.deleteMany(mongoC, nconf.get('schema').experiments, {
+    id: { $exists: true },
+  });
+
+  logger('Cleaning all supporters...');
+  await mongo.deleteMany(mongoC, nconf.get('schema').supporters, {
+    id: { $exists: true },
+  });
+
+  await mongoC.close();
+};
+
+void run();

--- a/platforms/yttrex/backend/scripts/clean-test-db.ts
+++ b/platforms/yttrex/backend/scripts/clean-test-db.ts
@@ -1,10 +1,9 @@
 #!/usr/bin/env ts-node
 /* eslint-disable camelcase */
-
-import D from 'debug';
 import dotenv from 'dotenv';
 import nconf from 'nconf';
-import * as mongo from '../../../../packages/shared/src/providers/mongo.provider';
+import { cleanTestDB } from '../../../../packages/shared/src/backend/scripts/clean-test-db';
+import { trexLogger } from '../../../../packages/shared/src/logger';
 
 dotenv.config({ path: '.env.development' });
 
@@ -12,45 +11,17 @@ const cfgFile = 'config/settings.json';
 
 nconf.argv().env().file({ file: cfgFile });
 
-const logger = D('yt:backend:clean-test-db');
-
 const run = async (): Promise<void> => {
   // ensure we're deleting data from the test db
-  nconf.set('mongoDb', 'yttrex-test');
 
-  const mongoC = await mongo.clientConnect();
-
-  logger('Cleaning all metadata...');
-  await mongo.deleteMany(mongoC, nconf.get('schema').metadata, {
-    id: { $exists: true },
-  });
-
-  logger('Cleaning all ads...');
-  await mongo.deleteMany(mongoC, nconf.get('schema').ads, {
-    id: { $exists: true },
-  });
-
-  logger('Cleaning all htmls...');
-  await mongo.deleteMany(mongoC, nconf.get('schema').htmls, {
-    id: { $exists: true },
-  });
-
-  logger('Cleaning all leaves...');
-  await mongo.deleteMany(mongoC, nconf.get('schema').leaves, {
-    id: { $exists: true },
-  });
-
-  logger('Cleaning all experiments...');
-  await mongo.deleteMany(mongoC, nconf.get('schema').experiments, {
-    id: { $exists: true },
-  });
-
-  logger('Cleaning all supporters...');
-  await mongo.deleteMany(mongoC, nconf.get('schema').supporters, {
-    id: { $exists: true },
-  });
-
-  await mongoC.close();
+  await cleanTestDB(trexLogger.extend('yt'), 'yttrex-test', [
+    nconf.get('schema').metadata,
+    nconf.get('schema').ads,
+    nconf.get('schema').htmls,
+    nconf.get('schema').leaves,
+    nconf.get('schema').experiments,
+    nconf.get('schema').supporters,
+  ]);
 };
 
 void run();

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,7 +11,9 @@ yarn workspaces foreach run clean
 
 # build shared
 yarn shared build
-./docs/scripts/build.sh
+
+# TODO: docs fail to build at the moment
+# ./docs/scripts/build.sh
 
 
 # build yttrex extension


### PR DESCRIPTION
This `hook` enforces to run `yarn build` (commented out at the moment cause `docs` aren't building) and `yarn test` before pushing, adding ~6 min to the time needed for push

With this in place we should have a better flow to be sure we're not pushing "wrong code", but it can be easily disable with `-n` at any occurrence