### PR TITLE
chore(workspace): defined issue template [skip ci]

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,39 @@
+name: 🐛 Bug Report
+description: Report a reproducible bug or regression in TrEx.
+labels: ["Needs: bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide all the information requested. Issues that do not follow this format are likely to stall.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Please provide a clear and concise description of what the bug is. Include screenshots if needed. Test using the [latest TrEx release](https://github.com/tracking-exposed/trex/releases/latest) to make sure your issue has not already been fixed.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What trex version does this appear on?
+      placeholder: ex. 2.7.0
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: Provide a detailed list of steps that reproduce the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: extra
+    attributes:
+      label: Code example, screenshot, or link to a repository
+      description: |
+        Please provide a link to a repository on GitHub, or provide a minimal code example that reproduces the problem.
+        You may provide a screenshot of the application if you think it is relevant to your bug report.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -14,6 +14,13 @@ body:
     validations:
       required: true
   - type: input
+    id: details
+    attributes:
+      label: Details
+      description: Often scraping and data processing fails because you might use a language that we do not support. If the issue is in content collection, please specify the langue of your browser and, if possible, which content is failing to collect. 
+    validations:
+      required: false
+  - type: input
     id: version
     attributes:
       label: Version

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+
+blank_issues_enabled: true
+contact_links:
+    - name: 📃 Documentation
+      url: https://docs.tracking.exposed
+      about: Please report documentation issues in the React Native website repository.
+    - name: 🚀 Discussions and Proposals
+      url: https://github.com/tracking-exposed/trex/discussions
+      about: Discuss the future of TrEx in the community's discussions and proposals section.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,24 @@
+<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->
+
+## Summary
+
+<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
+
+## Changelog
+
+<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
+https://github.com/tracking-exposed/trex/releases/tag/v2.7.1
+-->
+
+[PLATFORM{:PROJECT?}] message
+
+## Test Plan
+
+<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
+
+```sh
+docker-compose up -d mongodb
+yarn build
+yarn test tk:backend
+[...]
+```


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
I'm adding some initial templates for issues and PRs to standardize the info we provide as input (issues) and as output (PR).
For the issue I have only defined a template for `bug` report and left the possibility to create them from a blank template.
The PR template is this one I'm using.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/tracking-exposed/trex/releases/tag/v2.7.1
-->

[workspace] defined bug report and PR template [skip ci]

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

[Github says](https://github.com/tracking-exposed/trex/blob/ef444117c9b794e9f52b4804f25017c3825baac6/.github/ISSUE_TEMPLATE/bug-report.yml) it is using the bug report as template for issues.
