### PR TITLE
fix(guardoni): experimentId parameter for download command

### DIFF
--- a/packages/shared/src/providers/api.provider.ts
+++ b/packages/shared/src/providers/api.provider.ts
@@ -164,7 +164,7 @@ export const MakeHTTPClient = (client: AxiosInstance): HTTPClient => {
               });
             }, e.Output.decode),
             TE.map((output) => {
-              apiLogger.debug('%s %s output: %O', e.Method, url, output);
+              // apiLogger.debug('%s %s output: %O', e.Method, url, output);
               return output;
             })
           );

--- a/platforms/guardoni/src/guardoni/cli.ts
+++ b/platforms/guardoni/src/guardoni/cli.ts
@@ -58,7 +58,7 @@ export type GuardoniCommandConfig =
     }
   | {
       run: 'download';
-      experiment: NonEmptyString;
+      experimentId: NonEmptyString;
       out: string;
       opts: DownloadExperimentOpts;
     }
@@ -203,7 +203,7 @@ export const GetGuardoniCLI: GetGuardoniCLI = (
             case 'download':
             default:
               return g.downloadExperiment(
-                command.experiment,
+                command.experimentId,
                 command.out,
                 command.opts
               );

--- a/platforms/guardoni/src/guardoni/experiment.ts
+++ b/platforms/guardoni/src/guardoni/experiment.ts
@@ -382,6 +382,10 @@ export const walkPaginatedRequest =
 
       return pipe(
         apiReqFn({ skip, amount }),
+        TE.mapLeft((e) => ({
+          ...e,
+          message: `Failed with skip(${skip}) and amount(${amount}): ${e.message}`,
+        })),
         TE.chain((r) => {
           // logger.debug('Response: %o', r);
           const total = getTotal(r);
@@ -414,6 +418,8 @@ export const downloadExperiment =
     out: string,
     opts: DownloadExperimentOpts
   ): TE.TaskEither<AppError, GuardoniSuccessOutput> => {
+    ctx.logger.debug('Download experiment %s', experimentId);
+
     const tkDownloads = sequenceS(TE.ApplicativePar)({
       metadata: walkPaginatedRequest(ctx.logger)(
         (q) =>


### PR DESCRIPTION
The `experimentId` parameter for `tk-download` wasn't passed properly, this made the command returning all possible datas from `metadata`, `apiRequests` and `sigiStates` collections