### PR TITLE
fix(tk:backend): remove redundant occurrence of 'api' from GET /api/v2/directives/public endpoint

### DIFF
--- a/platforms/tktrex/backend/bin/app.ts
+++ b/platforms/tktrex/backend/bin/app.ts
@@ -66,7 +66,7 @@ export const makeApp = async (
 
   apiRouter.get('/v2/guardoni/list', iowrapper('getAllExperiments'));
 
-  apiRouter.get('/api/v2/directives/public', iowrapper('getPublicDirectives'));
+  apiRouter.get('/v2/directives/public', iowrapper('getPublicDirectives'));
 
   apiRouter.post('/v2/directives', iowrapper('postDirective'));
   apiRouter.get('/v2/directives/:experimentId', iowrapper('fetchDirective'));


### PR DESCRIPTION
## Test Plan

```
docker-compose up -d mongodb
docker-compose up -d mongo-tk-indexes
docker-compose up -d mongo-yt-indexes
yarn tk:backend build
yarn yt:backend build
yarn guardoni build:cli
cd platforms/guardoni
yarn cli tk-list
yarn cli yt-list
```