### PR TITLE
docs(yt:ext): docs extension improvements

### DIFF
--- a/docs/docs/partials/extension/_development.mdx
+++ b/docs/docs/partials/extension/_development.mdx
@@ -6,14 +6,7 @@ import CodeBlock from '@theme/CodeBlock';
 
 
 ### Prerequisites
-
-<ul>
-  <li>
-    <a href="backend">
-      @{props.platformPrefix}trex/backend
-    </a>{" "}up and running
-  </li>
-</ul>
+* <a href="backend">@{props.platformPrefix}trex/backend</a> up and running
 
 ### Run "watch" mode
 
@@ -23,4 +16,7 @@ To start developing the extension you need to compile the source code with `webp
   yarn {props.platformPrefix}:ext watch
 </CodeBlock>
 
-<p>then, you can open your browser's development panel and load the extension from the output folder <i>{props.platformPrefix}</i>.</p>
+### Load the extension
+
+In your browser's development panel or in your extension manager, load the extension from the <i>{props.platformPrefix}</i> output folder. To do that, you will need to navigate to `platforms/yttrex/extension/build` and load the extension from that folder.
+

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -24,7 +24,7 @@
   --ifm-color-primary-light: #67c8bf;
   --ifm-color-primary-lighter: #71ccc3;
   --ifm-color-primary-lightest: #90d7d0;
-  --ifm-code-font-size: 95%;
+  --ifm-code-font-size: 75%;
   --ifm-footer-background-color: #53c1b6;
   --ifm-footer-color: var(--white);
   --ifm-footer-title-color: var(--black);
@@ -101,4 +101,10 @@ h1{
 }
 h2 {
   padding-top: 4%;
+}
+
+@media (min-width: 997px) {
+  .docItemCol_---node_modules-\@docusaurus-theme-classic-lib-theme-DocItem-Layout-styles-module {
+    max-width: 80% !important;
+  }
 }

--- a/platforms/yttrex/docs/docs/backend.md
+++ b/platforms/yttrex/docs/docs/backend.md
@@ -1,3 +1,9 @@
+---
+sidebar_position: 3
+title: Backend
+id: backend
+---
+
 import CodeBlock from '@theme/CodeBlock';
 
 **Build the backend for development:**

--- a/platforms/yttrex/docs/docs/backend.md
+++ b/platforms/yttrex/docs/docs/backend.md
@@ -1,6 +1,22 @@
----
-title: Backend
-sidebar_position: 3
----
+import CodeBlock from '@theme/CodeBlock';
 
-The `@tktrex/shared` module contains `endpoints`, `models` and other definitions needed by `@tktrex` ecosystem.
+**Build the backend for development:**
+
+- Start the mongoDB container:
+  <CodeBlock className="language-bash">
+  docker-compose up -d mongodb
+  </CodeBlock>
+
+- Start the mongo-indexes container:
+  <CodeBlock className="language-bash">
+  docker-compose up -d mongo-yt-indexes
+  </CodeBlock>
+- Start the backend:
+  <CodeBlock className="language-bash">
+  yarn pm2 start platforms/yttrex/backend/ecosystem.dev.config.js
+  </CodeBlock>
+
+- [Optional] Set the watcher for the logs:
+  <CodeBlock className="language-bash">
+  yarn pm2 logs yt:backend:watch
+  </CodeBlock>

--- a/platforms/yttrex/docs/docs/enviroment.mdx
+++ b/platforms/yttrex/docs/docs/enviroment.mdx
@@ -1,0 +1,218 @@
+---
+sidebar_position: 4
+title: Enviroment Variables
+id: api
+---
+
+import style from './markdown-styles.module.css';
+
+<h2>Shared enviroment variables</h2>
+
+<p className={style.env_var}>
+  <span className="title">API_ROOT</span>
+  <div>
+    Points to the top level API URL.  
+    <div>
+      <strong>Default:</strong>
+      <ul>
+        <li>
+          Production:
+          <code>
+            <span>https://youtube.tracking.exposed/api</span>
+          </code>
+        </li>
+        <li>
+          Development:
+          <code>
+            <span>http://localhost:9000/api</span>
+          </code>
+        </li>
+      </ul>
+    </div>
+  </div>
+</p>
+<p className={style.env_var}>
+  <span className="title">WEB_ROOT
+</span>
+  <div>
+    Poins to the tracking exposed YT page.
+    <div>
+      <strong>Default:</strong>
+      <ul>
+        <li>
+          Production:
+          <code>
+            <span>https://youtube.tracking.exposed</span>
+          </code>
+        </li>
+        <li>
+          Development:
+          <code>
+            <span>http://localhost:1313</span>
+          </code>
+        </li>
+      </ul>
+    </div>
+  </div>
+</p>
+<p className={style.env_var}>
+  <span className="title">DATA_CONTRIBUTION_ENABLED</span>
+  <div>
+    Dictates if the extension should send data to the server.
+    <div>
+      <strong>Default:</strong>
+      <ul>
+        <li>
+          Production:
+          <code>
+            <span>false</span>
+          </code>
+        </li>
+        <li>
+          Development:
+          <code>
+            <span>true</span>
+          </code>
+        </li>
+      </ul>
+    </div>
+  </div>
+</p>
+<p className={style.env_var}>
+  <span className="title">FLUSH_INTERVAL</span>
+  <div>
+    How often the extension sends data to the server, measured in ms.
+    <div>
+      <strong>Default:</strong>
+      <ul>
+        <li>
+          Production:
+          <code>
+            <span>10000</span>
+          </code>
+        </li>
+        <li>
+          Development:
+          <code>
+            <span>4000</span>
+          </code>
+        </li>
+      </ul>
+    </div>
+  </div>
+</p>
+<p className={style.env_var}>
+  <span className="title">DEBUG</span>
+  <div>
+    Allows you to toggle the debug output for different parts of your module as well as the module as a whole.
+    <div>
+      <strong>Default:</strong>
+      <ul>
+        <li>
+          Production:
+          <code>
+            <span>@trex\*</span>
+          </code>
+        </li>
+        <li>
+          Development:
+          <code>
+            <span>@trex\*</span>
+          </code>
+        </li>
+      </ul>
+    </div>
+  </div>
+</p>
+
+<h2>Development enviroment variables</h2>
+
+<p className={style.env_var}>
+  <span className="title">BUNDLE_TARGET</span>
+  <div>
+    Allows you to configure the extension output depending on the browser.
+    <div>
+      <strong>Default:</strong>
+      <ul>
+        <li>
+          Development:
+          <code>
+            <span>firefox</span>
+          </code>
+        </li>
+      </ul>
+    </div>
+  </div>
+</p>
+<p className={style.env_var}>
+  <span className="title">BUILD_TRANSPILE_ONLY</span>
+  <div>
+    Avoids typescript type cheking on build.
+    <div>
+      <strong>Default:</strong>
+      <ul>
+        <li>
+          Development:
+          <code>
+            <span>true</span>
+          </code>
+        </li>
+      </ul>
+    </div>
+  </div>
+</p>
+<p className={style.env_var}>
+  <span className="title">NODE_ENV</span>
+  <div>
+    Used by Express to alter its own default behavior.
+    <div>
+      <strong>Default:</strong>
+      <ul>
+        <li>
+          Development:
+          <code>
+            <span>development</span>
+          </code>
+        </li>
+      </ul>
+    </div>
+  </div>
+</p>
+
+<h2>Guardoni enviroment variables</h2>
+
+<p className={style.env_var}>
+  <span className="title">PUBLIC_KEY</span>
+  <div>
+    Guardoni Public Key
+    <div>
+      <strong>Default:</strong>
+      <ul>
+        <li>
+          <code>
+            <span>H7AsuUszehN4qKTj2GYYwNNzkJVqUQBRo2wgKevzeUwx</span>
+          </code>
+        </li>
+      </ul>
+    </div>
+  </div>
+</p>
+
+<p className={style.env_var}>
+  <span className="title">SECRET_KEY</span>
+  <div>
+    Guardoni Secret Key
+    <div>
+      <strong>Default:</strong>
+      <ul>
+        <li>
+          <code>
+            <span>v6pyCC8TzKd1uq7LnGaLQDaZ4qmJwKCne7moXwr1EJthxne4sqBWPkHwqyH8QH5n9pNQGAGBeA9hZ1jwy4hUyeW
+</span>
+          </code>
+        </li>
+      </ul>
+    </div>
+  </div>
+</p>
+

--- a/platforms/yttrex/docs/docs/intro.md
+++ b/platforms/yttrex/docs/docs/intro.md
@@ -5,3 +5,5 @@ id: yttrex-intro
 ---
 
 # Introduction
+
+Welcome to the Youtube Scraper guide.

--- a/platforms/yttrex/docs/docs/markdown-styles.module.css
+++ b/platforms/yttrex/docs/docs/markdown-styles.module.css
@@ -1,0 +1,18 @@
+.env_var{
+    margin-bottom: 40px !important;
+}
+.env_var > span{
+    background: #25c2a0;
+    color: #1b1b1b;
+    padding: 2px 5px;
+    border-radius: 3px;
+    font-weight: bold;
+}
+
+.env_var code{
+    margin-left: 5px;
+}
+
+.env_var li{
+    list-style: none;
+}


### PR DESCRIPTION
## Summary

PR intended to write a better documentation for the project.

## Test Plan

To run it in dev mode run the following commands from the root folder:
`./docs/scripts/build.sh`
`yarn docs start`

and visit: http://localhost:3000/yttrex/docs/extension and http://localhost:3000/yttrex/docs/backend

