### PR TITLE
fix(shared): omit '_id' field from metadata when upsert from parsing

### DIFF
--- a/platforms/yttrex/backend/lib/parser/html.ts
+++ b/platforms/yttrex/backend/lib/parser/html.ts
@@ -87,11 +87,12 @@ export const getMetadata =
 export const updateMetadataAndMarkHTML =
   (db: ParserProviderContextDB): SaveResults<HTMLSource, Metadata> =>
   async (source, metadata) => {
+    const { _id, ...m }: any = metadata;
     const r = await db.api.upsertOne(
       db.write,
       getMetadataSchema(),
       { id: source.html.metadataId },
-      metadata
+      m
     );
 
     // parserLog.debug('Upsert metadata by %O: %O', { id: e.id }, r);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This solves a bug on `yt:parser` (and potentially `tk:parser`) where the _metadata_ upsert failed for having `_id` in the update payload.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/tracking-exposed/trex/releases/tag/v2.7.1
-->

fix(shared): omit '_id' field from metadata when upsert from parsing

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

```sh
docker-compose up -d mongo-yt-indexes
yarn pm2 start platforms/yttrex/backend/ecosystem.dev.config.js
yarn yt:ext watch
# in another pane
yarn pm2 logs
[...]
```

Load the extension in your browser and navigate in YT, you should have no errors.
